### PR TITLE
Fix/oncall userid and layerorder

### DIFF
--- a/internal/oncall/schedule.go
+++ b/internal/oncall/schedule.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -38,14 +39,14 @@ type WeeklyRotation struct {
 
 // DayAssignment maps a weekday name to a user.
 type DayAssignment struct {
-	Day    string    `json:"day"`     // monday…sunday
+	Day    string    `json:"day"` // monday…sunday
 	UserID uuid.UUID `json:"user_id"`
 }
 
 // LayeredRotation is the new format supporting multiple simultaneous on-call
 // layers, time-window restrictions, and index-based rotation.
 type LayeredRotation struct {
-	Type                  string  `json:"type"` // "layered"
+	Type                  string  `json:"type"`                    // "layered"
 	RotationStart         string  `json:"rotation_start"`          // RFC3339 anchor time
 	RotationIntervalHours float64 `json:"rotation_interval_hours"` // e.g. 168 = weekly
 	Layers                []Layer `json:"layers"`
@@ -63,8 +64,8 @@ type Layer struct {
 // TimeRestriction controls when a layer is active.
 type TimeRestriction struct {
 	// Type: "always" | "weekdays" | "weekends" | "custom"
-	Type    string         `json:"type"`
-	Windows []TimeWindow   `json:"windows,omitempty"` // only for type="custom"
+	Type    string       `json:"type"`
+	Windows []TimeWindow `json:"windows,omitempty"` // only for type="custom"
 }
 
 // TimeWindow is a recurring weekly time block (start inclusive, end exclusive).
@@ -131,6 +132,28 @@ func ResolveAllLayersAt(raw []byte, t time.Time) ([]LayerResult, error) {
 	}
 }
 
+// sortedLayers returns a copy of the input ordered by LayerOrder.
+// Positive LayerOrder values are sorted ascending (1 = first notified).
+// Layers with zero or negative LayerOrder are left after explicitly ordered layers.
+func sortedLayers(layers []Layer) []Layer {
+	out := append([]Layer(nil), layers...)
+	sort.SliceStable(out, func(i, j int) bool {
+		li, lj := out[i].LayerOrder, out[j].LayerOrder
+
+		switch {
+		case li <= 0 && lj <= 0:
+			return false
+		case li <= 0:
+			return false
+		case lj <= 0:
+			return true
+		default:
+			return li < lj
+		}
+	})
+	return out
+}
+
 func resolveLayeredAllLayers(raw []byte, t time.Time) ([]LayerResult, error) {
 	var rot LayeredRotation
 	if err := json.Unmarshal(raw, &rot); err != nil {
@@ -149,7 +172,8 @@ func resolveLayeredAllLayers(raw []byte, t time.Time) ([]LayerResult, error) {
 		elapsed = 0
 	}
 	var results []LayerResult
-	for _, layer := range rot.Layers {
+	// Return one result per layer in LayerOrder, regardless of the original JSON slice order.
+	for _, layer := range sortedLayers(rot.Layers) {
 		name := layer.Name
 		if name == "" {
 			name = fmt.Sprintf("Layer %d", layer.LayerOrder)
@@ -238,11 +262,47 @@ func (m *Manager) GetEscalationChain(ctx context.Context, teamID uuid.UUID) ([]E
 	now := time.Now()
 	var steps []EscalationStep
 	for i, layer := range cfg.Layers {
+		// Exactly one of ScheduleID or UserID must be set for a valid escalation layer.
+		if (layer.ScheduleID == "") == (layer.UserID == "") {
+			return nil, fmt.Errorf(
+				"invalid escalation layer %d (%s): exactly one of schedule_id or user_id must be set",
+				i, layer.LayerName,
+			)
+		}
+
+		// UserID-only layers notify a fixed user directly without schedule resolution.
+		if layer.UserID != "" {
+			userID, err := uuid.Parse(layer.UserID)
+			if err != nil {
+				log.Printf("escalation layer %d (%s): invalid user_id %q: %v", i, layer.LayerName, layer.UserID, err)
+				continue
+			}
+
+			member, err := m.cfg.GetMemberByID(ctx, userID)
+			if err != nil {
+				log.Printf("escalation layer %d (%s): member %s not found: %v", i, layer.LayerName, userID, err)
+				continue
+			}
+			if member == nil {
+				log.Printf("escalation layer %d (%s): member %s not found", i, layer.LayerName, userID)
+				continue
+			}
+
+			steps = append(steps, EscalationStep{
+				User:               member,
+				NotifyAfterMinutes: layer.NotifyAfterMinutes,
+				LayerName:          layer.LayerName,
+			})
+			continue
+		}
+
+		// ScheduleID-based layers resolve through the configured schedule and override flow.
 		schedID, err := uuid.Parse(layer.ScheduleID)
 		if err != nil {
 			log.Printf("escalation layer %d: invalid schedule_id %q: %v", i, layer.ScheduleID, err)
 			continue
 		}
+
 		schedule, err := m.cfg.GetScheduleByID(ctx, schedID, teamID)
 		if err != nil {
 			log.Printf("escalation layer %d (%s): schedule not found: %v", i, layer.LayerName, err)
@@ -252,11 +312,13 @@ func (m *Manager) GetEscalationChain(ctx context.Context, teamID uuid.UUID) ([]E
 			log.Printf("escalation layer %d (%s): schedule %s not found", i, layer.LayerName, schedID)
 			continue
 		}
+
 		override, err := m.cfg.GetActiveOverrideForSchedule(ctx, schedule.ID, teamID, now)
 		if err != nil {
 			log.Printf("escalation layer %d (%s): override check failed: %v", i, layer.LayerName, err)
 			// Fall through to rotation — don't skip the layer entirely.
 		}
+
 		var memberID uuid.UUID
 		if override != nil {
 			memberID = override.UserID
@@ -272,11 +334,17 @@ func (m *Manager) GetEscalationChain(ctx context.Context, teamID uuid.UUID) ([]E
 			}
 			memberID = uid
 		}
+
 		member, err := m.cfg.GetMemberByID(ctx, memberID)
 		if err != nil {
 			log.Printf("escalation layer %d (%s): member %s not found: %v", i, layer.LayerName, memberID, err)
 			continue
 		}
+		if member == nil {
+			log.Printf("escalation layer %d (%s): member %s not found", i, layer.LayerName, memberID)
+			continue
+		}
+
 		steps = append(steps, EscalationStep{
 			User:               member,
 			NotifyAfterMinutes: layer.NotifyAfterMinutes,
@@ -361,8 +429,8 @@ func resolveLayered(raw []byte, t time.Time) (uuid.UUID, error) {
 		anchor = startOfWeek(t)
 	}
 
-	// Sort layers by order (assume already sorted; pick first active).
-	for _, layer := range rot.Layers {
+	// Evaluate layers in LayerOrder so the first active layer is the current on-call user.
+	for _, layer := range sortedLayers(rot.Layers) {
 		if len(layer.Members) == 0 {
 			continue
 		}

--- a/internal/oncall/schedule_test.go
+++ b/internal/oncall/schedule_test.go
@@ -994,3 +994,207 @@ func TestManager_GetEscalationChain_NoPolicy(t *testing.T) {
 		t.Errorf("expected immediate notification, got %d min", steps[0].NotifyAfterMinutes)
 	}
 }
+
+// ── Regression tests for issue #8 — LayerOrder not respected ─────────────────
+
+// TestResolveLayered_LayerOrderEnforced verifies that resolveLayered returns
+// the user from the layer with the lowest LayerOrder, regardless of JSON order.
+// Layers are intentionally stored secondary-first, primary-second to expose the bug.
+func TestResolveLayered_LayerOrderEnforced(t *testing.T) {
+	primaryUser := uuid.New()
+	secondaryUser := uuid.New()
+	anchor := time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)
+
+	// Secondary (order=2) is first in JSON — primary (order=1) is second.
+	// The fix must sort by LayerOrder before picking the first active layer.
+	rot := LayeredRotation{
+		Type:                  "layered",
+		RotationStart:         anchor.Format(time.RFC3339),
+		RotationIntervalHours: 168,
+		Layers: []Layer{
+			{
+				ID:              "secondary",
+				Name:            "Secondary",
+				LayerOrder:      2,
+				TimeRestriction: TimeRestriction{Type: "always"},
+				Members:         []uuid.UUID{secondaryUser},
+			},
+			{
+				ID:              "primary",
+				Name:            "Primary",
+				LayerOrder:      1,
+				TimeRestriction: TimeRestriction{Type: "always"},
+				Members:         []uuid.UUID{primaryUser},
+			},
+		},
+	}
+	raw, _ := json.Marshal(rot)
+
+	uid, err := resolveLayered(raw, anchor.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uid != primaryUser {
+		t.Errorf("expected primaryUser (LayerOrder=1), got %v — layers were not sorted by LayerOrder", uid)
+	}
+}
+
+// TestResolveAllLayersAt_LayerOrderEnforced verifies that ResolveAllLayersAt
+// returns results sorted by LayerOrder, not by JSON array position.
+func TestResolveAllLayersAt_LayerOrderEnforced(t *testing.T) {
+	primaryUser := uuid.New()
+	secondaryUser := uuid.New()
+	anchor := time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)
+
+	// Secondary (order=2) is first in JSON — primary (order=1) is second.
+	rot := LayeredRotation{
+		Type:                  "layered",
+		RotationStart:         anchor.Format(time.RFC3339),
+		RotationIntervalHours: 168,
+		Layers: []Layer{
+			{
+				ID:              "secondary",
+				Name:            "Secondary",
+				LayerOrder:      2,
+				TimeRestriction: TimeRestriction{Type: "always"},
+				Members:         []uuid.UUID{secondaryUser},
+			},
+			{
+				ID:              "primary",
+				Name:            "Primary",
+				LayerOrder:      1,
+				TimeRestriction: TimeRestriction{Type: "always"},
+				Members:         []uuid.UUID{primaryUser},
+			},
+		},
+	}
+	raw, _ := json.Marshal(rot)
+
+	monday := anchor.Add(time.Hour)
+	results, err := ResolveAllLayersAt(raw, monday)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].UserID != primaryUser {
+		t.Errorf("results[0] should be primary (LayerOrder=1), got UserID=%v — layers not sorted", results[0].UserID)
+	}
+	if results[1].UserID != secondaryUser {
+		t.Errorf("results[1] should be secondary (LayerOrder=2), got UserID=%v", results[1].UserID)
+	}
+}
+
+// ── Regression tests for issue #7 — UserID ignored in GetEscalationChain ─────
+
+// TestManager_GetEscalationChain_FixedUserLayer verifies that an escalation layer
+// with only UserID set (no ScheduleID) resolves directly to that fixed user,
+// without requiring a schedule lookup.
+func TestManager_GetEscalationChain_FixedUserLayer(t *testing.T) {
+	fixedUserID := uuid.New()
+	teamID := uuid.New()
+
+	policyCfg, _ := json.Marshal(EscalationConfig{
+		Layers: []EscalationLayer{
+			// UserID set, ScheduleID intentionally empty — fixed person, not a rotation.
+			{UserID: fixedUserID.String(), NotifyAfterMinutes: 0, LayerName: "manager"},
+		},
+	})
+
+	mock := &mockConfigStore{
+		escalationPolicy: &store.EscalationPolicy{
+			TeamID: teamID,
+			Config: policyCfg,
+		},
+		member: &store.TeamMember{ID: fixedUserID, Name: "Alice Manager"},
+	}
+
+	m := NewManager(mock)
+	steps, err := m.GetEscalationChain(context.Background(), teamID)
+	if err != nil {
+		t.Fatalf("expected UserID-only layer to resolve successfully, got error: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 escalation step, got %d", len(steps))
+	}
+	if steps[0].User == nil || steps[0].User.ID != fixedUserID {
+		t.Errorf("expected fixed user %v, got %v — UserID field is ignored", fixedUserID, steps[0].User)
+	}
+	if steps[0].LayerName != "manager" {
+		t.Errorf("expected layer name 'manager', got %q", steps[0].LayerName)
+	}
+}
+
+// TestManager_GetEscalationChain_BothIDsSet_Rejected verifies that a layer
+// with both ScheduleID and UserID set is rejected — exactly one must be set.
+func TestManager_GetEscalationChain_BothIDsSet_Rejected(t *testing.T) {
+	schedID := uuid.New()
+	userID := uuid.New()
+	teamID := uuid.New()
+
+	rot := WeeklyRotation{
+		Type:     "weekly",
+		Rotation: []DayAssignment{{Day: weekdayName(time.Now().Weekday()), UserID: uuid.New()}},
+	}
+	raw, _ := json.Marshal(rot)
+
+	policyCfg, _ := json.Marshal(EscalationConfig{
+		Layers: []EscalationLayer{
+			{
+				ScheduleID:         schedID.String(),
+				UserID:             userID.String(),
+				NotifyAfterMinutes: 0,
+				LayerName:          "ambiguous",
+			},
+		},
+	})
+
+	mock := &mockConfigStore{
+		schedule: &store.Schedule{
+			ID:             schedID,
+			TeamID:         teamID,
+			RotationConfig: raw,
+		},
+		escalationPolicy: &store.EscalationPolicy{
+			TeamID: teamID,
+			Config: policyCfg,
+		},
+		member: &store.TeamMember{ID: userID, Name: "Alice"},
+	}
+
+	m := NewManager(mock)
+	_, err := m.GetEscalationChain(context.Background(), teamID)
+	if err == nil {
+		t.Error("expected error when both ScheduleID and UserID are set in the same layer — exactly one must be set")
+	}
+}
+
+// TestManager_GetEscalationChain_NeitherIDSet_Rejected verifies that a layer
+// with neither ScheduleID nor UserID returns a clear misconfiguration error.
+func TestManager_GetEscalationChain_NeitherIDSet_Rejected(t *testing.T) {
+	teamID := uuid.New()
+
+	policyCfg, _ := json.Marshal(EscalationConfig{
+		Layers: []EscalationLayer{
+			{
+				// Both fields empty — layer is misconfigured.
+				NotifyAfterMinutes: 0,
+				LayerName:          "empty",
+			},
+		},
+	})
+
+	mock := &mockConfigStore{
+		escalationPolicy: &store.EscalationPolicy{
+			TeamID: teamID,
+			Config: policyCfg,
+		},
+	}
+
+	m := NewManager(mock)
+	_, err := m.GetEscalationChain(context.Background(), teamID)
+	if err == nil {
+		t.Error("expected error when neither ScheduleID nor UserID is set — layer is misconfigured")
+	}
+}

--- a/internal/oncall/schedule_test.go
+++ b/internal/oncall/schedule_test.go
@@ -550,8 +550,8 @@ func TestWindowCovers_Simple(t *testing.T) {
 		t      time.Time
 		covers bool
 	}{
-		{time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC), true},   // Mon 09:00 exactly (inclusive)
-		{time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC), true},  // Mon 12:00
+		{time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC), true},    // Mon 09:00 exactly (inclusive)
+		{time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC), true},   // Mon 12:00
 		{time.Date(2025, 1, 10, 16, 59, 0, 0, time.UTC), true}, // Fri 16:59
 		{time.Date(2025, 1, 10, 17, 0, 0, 0, time.UTC), false}, // Fri 17:00 (exclusive)
 		{time.Date(2025, 1, 11, 10, 0, 0, 0, time.UTC), false}, // Sat
@@ -573,12 +573,12 @@ func TestWindowCovers_WrapAroundMidnight(t *testing.T) {
 		t      time.Time
 		covers bool
 	}{
-		{time.Date(2025, 1, 10, 22, 0, 0, 0, time.UTC), true},  // Fri 22:00
-		{time.Date(2025, 1, 11, 12, 0, 0, 0, time.UTC), true},  // Sat noon
-		{time.Date(2025, 1, 12, 3, 0, 0, 0, time.UTC), true},   // Sun 03:00
-		{time.Date(2025, 1, 6, 7, 0, 0, 0, time.UTC), true},    // Mon 07:00
-		{time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC), false},   // Mon 09:00 — outside
-		{time.Date(2025, 1, 8, 12, 0, 0, 0, time.UTC), false},  // Wed noon — outside
+		{time.Date(2025, 1, 10, 22, 0, 0, 0, time.UTC), true}, // Fri 22:00
+		{time.Date(2025, 1, 11, 12, 0, 0, 0, time.UTC), true}, // Sat noon
+		{time.Date(2025, 1, 12, 3, 0, 0, 0, time.UTC), true},  // Sun 03:00
+		{time.Date(2025, 1, 6, 7, 0, 0, 0, time.UTC), true},   // Mon 07:00
+		{time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC), false},  // Mon 09:00 — outside
+		{time.Date(2025, 1, 8, 12, 0, 0, 0, time.UTC), false}, // Wed noon — outside
 	}
 
 	for _, tt := range tests {
@@ -1167,6 +1167,35 @@ func TestManager_GetEscalationChain_BothIDsSet_Rejected(t *testing.T) {
 	_, err := m.GetEscalationChain(context.Background(), teamID)
 	if err == nil {
 		t.Error("expected error when both ScheduleID and UserID are set in the same layer — exactly one must be set")
+	}
+}
+
+// TestManager_GetEscalationChain_BothIDsEmpty_Rejected verifies that a layer
+// with neither ScheduleID nor UserID set is rejected — exactly one must be set.
+func TestManager_GetEscalationChain_BothIDsEmpty_Rejected(t *testing.T) {
+	teamID := uuid.New()
+
+	policyCfg, _ := json.Marshal(EscalationConfig{
+		Layers: []EscalationLayer{
+			{
+				NotifyAfterMinutes: 0,
+				LayerName:          "bad",
+			},
+		},
+	})
+
+	mock := &mockConfigStore{
+		escalationPolicy: &store.EscalationPolicy{
+			TeamID: teamID,
+			Config: policyCfg,
+		},
+	}
+
+	m := NewManager(mock)
+
+	_, err := m.GetEscalationChain(context.Background(), teamID)
+	if err == nil {
+		t.Fatal("expected validation error when neither schedule_id nor user_id is set")
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes & Closes #7
Fixes & Closes #8

- support `EscalationLayer.UserID` in `GetEscalationChain`
- reject invalid escalation layers where both `schedule_id` and `user_id` are set
- reject invalid escalation layers where both are empty
- sort layered schedules by `LayerOrder` before resolving
- use sorted layers in both `resolveLayered` and `ResolveAllLayersAt`
- include the maintainer-provided regression tests from `test/oncall-bug-specs`
- add coverage for the both-empty validation case


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

- gofmt -w internal/oncall/schedule.go internal/oncall/schedule_test.go
- go test ./internal/oncall/...
- go test ./...
- go vet ./...
- go build ./...

- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

<!-- Closes #<issue number> -->
#7 
#8 