### PR TITLE
fix: store timestamps as UTC in all time.Now() calls

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -51,6 +51,12 @@ func NewDB(databaseURL string) (*DB, error) {
 		config.ConnConfig.Password = pw
 	}
 
+	// Force the PostgreSQL session timezone to UTC so that SQL-side NOW() and
+	// DEFAULT NOW() write UTC regardless of the host machine's local timezone.
+	// This complements time.Now().UTC() on the Go side — both must be UTC to
+	// avoid skew on developer machines in non-UTC timezones (e.g. Norway UTC+2).
+	config.ConnConfig.RuntimeParams["TimeZone"] = "UTC"
+
 	// Set connection pool settings
 	config.MaxConns = 20
 	config.MinConns = 2

--- a/internal/store/incidents.go
+++ b/internal/store/incidents.go
@@ -35,7 +35,7 @@ func (db *DB) CreateIncident(ctx context.Context, incident *Incident) error {
 		)
 	`
 
-	now := time.Now()
+	now := time.Now().UTC()
 	incident.ID = uuid.New()
 	incident.CreatedAt = now
 	incident.UpdatedAt = now
@@ -165,7 +165,7 @@ func (db *DB) UpdateIncidentStatus(ctx context.Context, teamID, incidentID uuid.
 		SET status = $1, updated_at = $2
 		WHERE id = $3 AND team_id = $4
 	`
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := db.pool.Exec(ctx, query, status, now, incidentID, teamID)
 	if err != nil {
 		return fmt.Errorf("failed to update incident status: %w", err)
@@ -184,7 +184,7 @@ func (db *DB) AcknowledgeIncident(ctx context.Context, teamID, incidentID uuid.U
 			updated_at = $1
 		WHERE id = $3 AND team_id = $4
 	`
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := db.pool.Exec(ctx, query, now, userID, incidentID, teamID)
 	if err != nil {
 		return fmt.Errorf("failed to acknowledge incident: %w", err)
@@ -262,7 +262,7 @@ func (i *Incident) ToResponse() (*IncidentResponse, error) {
 // GetOpenIncidentsForEscalation returns open incidents that fired at least minAge ago.
 // Used by the worker's escalation loop to find candidates for the next escalation step.
 func (db *DB) GetOpenIncidentsForEscalation(ctx context.Context, minAge time.Duration) ([]*Incident, error) {
-	cutoff := time.Now().Add(-minAge)
+	cutoff := time.Now().UTC().Add(-minAge)
 	query := `
 		SELECT
 			id, team_id, title, message, severity, status, source,
@@ -318,7 +318,7 @@ func (db *DB) IncrementEscalationStep(ctx context.Context, teamID, incidentID uu
 		UPDATE incidents
 		SET escalation_step = escalation_step + 1, updated_at = $1
 		WHERE id = $2 AND team_id = $3 AND escalation_step = $4 AND status = 'open'
-	`, time.Now(), incidentID, teamID, fromStep)
+	`, time.Now().UTC(), incidentID, teamID, fromStep)
 	if err != nil {
 		return false, fmt.Errorf("failed to increment escalation step: %w", err)
 	}

--- a/internal/store/local_users.go
+++ b/internal/store/local_users.go
@@ -188,7 +188,7 @@ func (db *DB) ResetFailedAttempts(ctx context.Context, id uuid.UUID) error {
 
 // RecordLocalLogin updates the last_login_at timestamp.
 func (db *DB) RecordLocalLogin(ctx context.Context, id uuid.UUID) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := db.pool.Exec(ctx, `
 		UPDATE local_users SET last_login_at = $2, updated_at = NOW() WHERE id = $1
 	`, id, now)

--- a/internal/store/notification_rules.go
+++ b/internal/store/notification_rules.go
@@ -78,7 +78,7 @@ func (db *DB) UpsertUserNotificationRule(ctx context.Context, r *UserNotificatio
 	if r.ID == uuid.Nil {
 		r.ID = uuid.New()
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	r.CreatedAt = now
 	r.UpdatedAt = now
 
@@ -134,7 +134,7 @@ func (db *DB) DeleteUserNotificationRule(ctx context.Context, id, userID uuid.UU
 // QueuePendingNotification inserts a delayed notification into the queue.
 func (db *DB) QueuePendingNotification(ctx context.Context, p *PendingNotification) error {
 	p.ID = uuid.New()
-	p.CreatedAt = time.Now()
+	p.CreatedAt = time.Now().UTC()
 	_, err := db.pool.Exec(ctx, `
 		INSERT INTO pending_notifications
 			(id, incident_id, team_id, user_id, user_source, channel, scheduled_at, created_at)

--- a/internal/store/system_config.go
+++ b/internal/store/system_config.go
@@ -40,7 +40,7 @@ func (db *DB) GetSystemConfig(ctx context.Context) (*SystemConfig, error) {
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &SystemConfig{AIBackend: "ollama", UpdatedAt: time.Now()}, nil
+			return &SystemConfig{AIBackend: "ollama", UpdatedAt: time.Now().UTC()}, nil
 		}
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (db *DB) UpsertSystemConfig(ctx context.Context, backend string, model *str
 			updated_by = EXCLUDED.updated_by
 		RETURNING ai_backend, ai_model, updated_at, updated_by
 	`
-	now := time.Now()
+	now := time.Now().UTC()
 	var sc SystemConfig
 	err := db.pool.QueryRow(ctx, query, backend, model, now, updatedBy).Scan(
 		&sc.AIBackend,
@@ -82,6 +82,6 @@ func (db *DB) SeedSystemConfig(ctx context.Context, backend string, model *strin
 		VALUES (1, $1, $2, $3)
 		ON CONFLICT (id) DO NOTHING
 	`
-	_, err := db.pool.Exec(ctx, query, backend, model, time.Now())
+	_, err := db.pool.Exec(ctx, query, backend, model, time.Now().UTC())
 	return err
 }

--- a/internal/store/team_config.go
+++ b/internal/store/team_config.go
@@ -91,7 +91,7 @@ func (db *DB) UpsertTeamConfig(ctx context.Context, tc *TeamConfig) error {
 			updated_at                = EXCLUDED.updated_at
 	`
 
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := db.pool.Exec(ctx, query,
 		tc.TeamID,
 		tc.SlackWebhookURL,


### PR DESCRIPTION
Closes #10

## What this fixes

On developer machines in non-UTC timezones (e.g. Norway UTC+2), `time.Now()` returns local time. Stored in a `TIMESTAMP` column and later treated as UTC, this caused a 2-hour skew — the GitHub commit window used for AI analysis missed recent commits entirely.

## Changes

**Go side (`time.Now().UTC()` in all store writes):**
- `internal/store/incidents.go` — `CreateIncident`, `UpdateIncidentStatus`, `AcknowledgeIncident`, `GetOpenIncidentsForEscalation`, `IncrementEscalationStep`
- `internal/store/local_users.go` — `RecordLocalLogin`
- `internal/store/system_config.go` — `GetSystemConfig` default, `UpsertSystemConfig`, `SeedSystemConfig`
- `internal/store/team_config.go` — `UpsertTeamConfig`
- `internal/store/notification_rules.go` — `UpsertUserNotificationRule`, `QueuePendingNotification`

**SQL side (`TimeZone=UTC` pgx runtime param in `NewDB`):**
- `internal/store/db.go` — sets `config.ConnConfig.RuntimeParams["TimeZone"] = "UTC"` so `NOW()` and `DEFAULT NOW()` in SQL also write UTC

This implements exactly the two-part fix @fatkobra recommended in #10.

## No production impact

AKS/EKS containers run in UTC — `time.Now()` and `time.Now().UTC()` produce identical results there. This only affects developer machines in non-UTC timezones.

@fatkobra — would appreciate your review given you diagnosed the SQL-side gap.