### PR TITLE
fix: security hardening — auth, SSRF, rate limit, override access

### DIFF
--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -59,12 +59,14 @@ import (
 // ── test harness ──────────────────────────────────────────────────────────────
 
 type e2eEnv struct {
-	db          *store.DB
-	router      *mux.Router
-	kongTeam    *store.Team
-	kafkaTeam   *store.Team
-	kongCookie  *http.Cookie // admin session scoped to Kong team only
-	kafkaCookie *http.Cookie // admin session scoped to Kafka team only
+	db                  *store.DB
+	router              *mux.Router
+	kongTeam            *store.Team
+	kafkaTeam           *store.Team
+	kongCookie          *http.Cookie // admin session scoped to Kong team only
+	kafkaCookie         *http.Cookie // admin session scoped to Kafka team only
+	kongResponderCookie *http.Cookie // responder session scoped to Kong team only
+	kongViewerCookie    *http.Cookie // viewer session scoped to Kong team only
 }
 
 // newE2EEnv spins up a full Server with real Postgres + Redis, creates two
@@ -136,18 +138,22 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	})
 
 	server := &Server{
-		db:            db,
-		queue:         q,
-		oncallManager: oncallMgr,
-		sessions:      sessions,
-		license:       lic,
-		enc:           enc,
+		cfg:            db,
+		db:             db,
+		queue:          q,
+		oncallManager:  oncallMgr,
+		sessions:       sessions,
+		license:        lic,
+		enc:            enc,
+		webhookLimiter: newWebhookIPLimiter(),
 	}
 
 	// Create per-team admin sessions. Sessions are stored in Redis and carry
 	// the Roles map directly — no DB user required for the e2e harness.
 	kongCookie := e2eSession(t, sessions, kongTeam.ID, "admin")
 	kafkaCookie := e2eSession(t, sessions, kafkaTeam.ID, "admin")
+	kongResponderCookie := e2eSession(t, sessions, kongTeam.ID, "responder")
+	kongViewerCookie := e2eSession(t, sessions, kongTeam.ID, "viewer")
 
 	// Build router — mirrors the relevant portion of main.go
 	router := mux.NewRouter()
@@ -166,14 +172,18 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	api.HandleFunc("/{teamId}/members", server.handleListMembers).Methods("GET")
 	api.HandleFunc("/{teamId}/config", server.handleGetTeamConfig).Methods("GET")
 	api.HandleFunc("/{teamId}/config", server.handleUpsertTeamConfig).Methods("PUT")
+	api.HandleFunc("/{teamId}/schedule/overrides", server.handleCreateOverride).Methods("POST")
+	api.HandleFunc("/{teamId}/members/{userId}", server.handleUpdateMember).Methods("PUT")
 
 	return &e2eEnv{
-		db:          db,
-		router:      router,
-		kongTeam:    kongTeam,
-		kafkaTeam:   kafkaTeam,
-		kongCookie:  kongCookie,
-		kafkaCookie: kafkaCookie,
+		db:                  db,
+		router:              router,
+		kongTeam:            kongTeam,
+		kafkaTeam:           kafkaTeam,
+		kongCookie:          kongCookie,
+		kafkaCookie:         kafkaCookie,
+		kongResponderCookie: kongResponderCookie,
+		kongViewerCookie:    kongViewerCookie,
 	}
 }
 
@@ -451,12 +461,12 @@ func TestE2E_TwoTeams_CrossTeamAccessIsForbidden(t *testing.T) {
 func TestE2E_TwoTeams_ConfigIsolation(t *testing.T) {
 	env := newE2EEnv(t)
 
-	// Kong admin sets Kong's Slack channel
+	// Kong admin sets Kong's Slack channel — no endpoint URLs, those trigger
+	// DNS validation which does not resolve test hostnames in CI.
 	req := httptest.NewRequest("PUT",
 		fmt.Sprintf("/api/v1/teams/%s/config", env.kongTeam.ID),
 		e2eBody(t, map[string]any{
-			"slack_channel":       "#kong-alerts",
-			"prometheus_endpoint": "http://prometheus.example.com:9090",
+			"slack_channel": "#kong-alerts",
 		}))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(env.kongCookie)
@@ -478,13 +488,10 @@ func TestE2E_TwoTeams_ConfigIsolation(t *testing.T) {
 	if cfg["slack_channel"] != "#kong-alerts" {
 		t.Errorf("kong config slack_channel: got %v, want #kong-alerts", cfg["slack_channel"])
 	}
-	if cfg["prometheus_endpoint"] != "http://prometheus.example.com:9090" {
-		t.Errorf("kong config prometheus_endpoint: got %v, want http://prometheus.example.com:9090",
-			cfg["prometheus_endpoint"])
-	}
-	// webhook_secret must be present so the UI can build the full webhook URL
-	if cfg["webhook_secret"] == "" || cfg["webhook_secret"] == nil {
-		t.Error("kong config response missing webhook_secret")
+	// webhook_secret must NOT be present in the config response — it is
+	// sensitive and returned only via the dedicated rotate-secret endpoint.
+	if cfg["webhook_secret"] != nil && cfg["webhook_secret"] != "" {
+		t.Error("kong config response must not include webhook_secret")
 	}
 
 	// Kafka admin cannot modify Kong's config
@@ -513,7 +520,6 @@ func TestE2E_TwoTeams_ConfigIsolation(t *testing.T) {
 		fmt.Sprintf("/api/v1/teams/%s/config", env.kafkaTeam.ID),
 		e2eBody(t, map[string]any{
 			"slack_channel": "#kafka-alerts",
-			"loki_endpoint": "http://loki.example.com:3100",
 		}))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(env.kafkaCookie)
@@ -618,13 +624,13 @@ func TestE2E_WebhookSecurity(t *testing.T) {
 			name:     "kong team ID with kafka secret",
 			teamID:   env.kongTeam.ID.String(),
 			secret:   env.kafkaTeam.WebhookSecret,
-			wantCode: http.StatusForbidden,
+			wantCode: http.StatusUnauthorized,
 		},
 		{
 			name:     "kafka team ID with kong secret",
 			teamID:   env.kafkaTeam.ID.String(),
 			secret:   env.kongTeam.WebhookSecret,
-			wantCode: http.StatusForbidden,
+			wantCode: http.StatusUnauthorized,
 		},
 		{
 			name:     "completely invalid secret",
@@ -679,5 +685,112 @@ func TestE2E_GetIncident_NotFoundReturns404(t *testing.T) {
 
 	if resp.Code != http.StatusNotFound {
 		t.Fatalf("get missing incident: got %d, want 404\nbody: %s", resp.Code, resp.Body)
+	}
+}
+
+// TestE2E_Override_ViewerIsDenied verifies that a team viewer cannot create
+// on-call overrides — only responders and admins are permitted.
+func TestE2E_Override_ViewerIsDenied(t *testing.T) {
+	env := newE2EEnv(t)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/teams/%s/schedule/overrides", env.kongTeam.ID),
+		e2eBody(t, map[string]any{
+			"user_id":  uuid.New().String(),
+			"start_at": "2026-05-01T00:00:00Z",
+			"end_at":   "2026-05-08T00:00:00Z",
+		}))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(env.kongViewerCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Errorf("viewer create override: got %d, want 403", resp.Code)
+	}
+}
+// admin role — a responder must receive 403 on both GET and PUT.
+func TestE2E_Config_RequiresAdmin(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Responder cannot read team config
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/api/v1/teams/%s/config", env.kongTeam.ID), nil)
+	req.AddCookie(env.kongResponderCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Errorf("responder GET config: got %d, want 403", resp.Code)
+	}
+
+	// Responder cannot write team config
+	req = httptest.NewRequest("PUT",
+		fmt.Sprintf("/api/v1/teams/%s/config", env.kongTeam.ID),
+		e2eBody(t, map[string]any{"slack_channel": "#hacked"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(env.kongResponderCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Errorf("responder PUT config: got %d, want 403", resp.Code)
+	}
+}
+
+// TestE2E_Webhook_BodyTooLarge verifies that a webhook payload over 1 MB is
+// rejected with 400 and does not exhaust server memory.
+func TestE2E_Webhook_BodyTooLarge(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Build a body just over the 1 MB limit
+	oversized := bytes.Repeat([]byte("x"), 1<<20+1)
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/webhook/%s/%s", env.kongTeam.ID, env.kongTeam.WebhookSecret),
+		bytes.NewBuffer(oversized))
+	req.Header.Set("Content-Type", "application/json")
+	resp := env.do(req)
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("oversized body: got %d, want 400", resp.Code)
+	}
+}
+
+// TestE2E_Override_UserMustBeTeamMember verifies that creating an override for
+// a user who does not belong to the team is rejected with 422.
+func TestE2E_Override_UserMustBeTeamMember(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Use a random UUID that is not a member of kong team
+	outsiderID := uuid.New()
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/teams/%s/schedule/overrides", env.kongTeam.ID),
+		e2eBody(t, map[string]any{
+			"user_id":  outsiderID.String(),
+			"start_at": "2026-05-01T00:00:00Z",
+			"end_at":   "2026-05-08T00:00:00Z",
+			"reason":   "test",
+		}))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(env.kongCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Errorf("override for non-member: got %d, want 422", resp.Code)
+	}
+}
+
+// TestE2E_UpdateMember_UserMustBeTeamMember verifies that updating the phone
+// number of a user outside the team is rejected with 422.
+func TestE2E_UpdateMember_UserMustBeTeamMember(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Use a random UUID that is not a member of kong team
+	outsiderID := uuid.New()
+
+	req := httptest.NewRequest("PUT",
+		fmt.Sprintf("/api/v1/teams/%s/members/%s", env.kongTeam.ID, outsiderID),
+		e2eBody(t, map[string]any{
+			"source": "local",
+			"phone":  "+4712345678",
+		}))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(env.kongCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Errorf("phone update for non-member: got %d, want 422", resp.Code)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -569,11 +569,21 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	secret := vars["secret"]
 
 	// Rate-limit per source IP — 20 burst, 1/s sustained.
-	ip := r.RemoteAddr
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		ip = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
-	} else if host, _, err := net.SplitHostPort(ip); err == nil {
-		ip = host
+	// Only trust X-Forwarded-For when the direct connection originates from a
+	// private/loopback address (in-cluster ingress/proxy). Trusting it
+	// unconditionally lets any client spoof arbitrary IPs to bypass the limiter.
+	remoteHost, _, splitErr := net.SplitHostPort(r.RemoteAddr)
+	if splitErr != nil {
+		remoteHost = r.RemoteAddr
+	}
+	var ip string
+	if remoteIP := net.ParseIP(remoteHost); remoteIP != nil && (remoteIP.IsLoopback() || remoteIP.IsPrivate()) {
+		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			ip = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
+		}
+	}
+	if ip == "" {
+		ip = remoteHost
 	}
 	if !s.webhookLimiter.allow(ip) {
 		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
@@ -620,7 +630,8 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read webhook payload
+	// Read webhook payload — limit to 1 MB to prevent memory exhaustion.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -1270,12 +1281,12 @@ func (s *Server) handleSnoozeIncident(w http.ResponseWriter, r *http.Request) {
 
 // teamConfigPublic is the API-safe view of TeamConfig.
 // It never exposes encrypted token values — only whether they are set.
+// WebhookSecret is intentionally omitted; use the rotate-secret endpoint to manage it.
 type teamConfigPublic struct {
-	TeamID             string   `json:"team_id"`
-	WebhookSecret      string   `json:"webhook_secret"`
-	SlackWebhookURL    *string  `json:"slack_webhook_url,omitempty"`
-	SlackChannel       *string  `json:"slack_channel,omitempty"`
-	GitHubTokenSet     bool     `json:"github_token_set"`
+	TeamID          string  `json:"team_id"`
+	SlackWebhookURL *string `json:"slack_webhook_url,omitempty"`
+	SlackChannel    *string `json:"slack_channel,omitempty"`
+	GitHubTokenSet  bool    `json:"github_token_set"`
 	GitHubRepos        []string `json:"github_repos,omitempty"`
 	PrometheusEndpoint *string  `json:"prometheus_endpoint,omitempty"`
 	LokiEndpoint       *string  `json:"loki_endpoint,omitempty"`
@@ -1298,14 +1309,8 @@ func (s *Server) handleGetTeamConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid team ID", http.StatusBadRequest)
 		return
 	}
-	if !s.requireTeamAccess(r, teamID) {
+	if !s.requireTeamAdmin(r, teamID) {
 		writeForbidden(w)
-		return
-	}
-
-	team, err := s.cfg.GetTeam(r.Context(), teamID)
-	if err != nil {
-		http.Error(w, "failed to load team", http.StatusInternalServerError)
 		return
 	}
 
@@ -1316,9 +1321,6 @@ func (s *Server) handleGetTeamConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pub := teamConfigPublic{TeamID: teamID.String()}
-	if team != nil {
-		pub.WebhookSecret = team.WebhookSecret
-	}
 	if cfg != nil {
 		pub.SlackWebhookURL = cfg.SlackWebhookURL
 		pub.SlackChannel = cfg.SlackChannel
@@ -1341,7 +1343,7 @@ func (s *Server) handleUpsertTeamConfig(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "invalid team ID", http.StatusBadRequest)
 		return
 	}
-	if !s.requireTeamAccess(r, teamID) {
+	if !s.requireTeamAdmin(r, teamID) {
 		writeForbidden(w)
 		return
 	}
@@ -1681,6 +1683,23 @@ func (s *Server) requireTeamAdmin(r *http.Request, teamID uuid.UUID) bool {
 	return sess.Roles[teamID.String()] == "admin"
 }
 
+// requireTeamResponder returns true for responders and admins. Use this for
+// self-service operations that viewers must not perform (e.g. creating overrides).
+func (s *Server) requireTeamResponder(r *http.Request, teamID uuid.UUID) bool {
+	if os.Getenv("AUTH_DISABLED") == "true" {
+		return true
+	}
+	sess := auth.SessionFromContext(r.Context())
+	if sess == nil {
+		return false
+	}
+	if sess.IsSuperAdmin {
+		return true
+	}
+	role := sess.Roles[teamID.String()]
+	return role == "responder" || role == "admin"
+}
+
 // callerID extracts the current user's UUID from the session for audit fields.
 func (s *Server) callerID(r *http.Request) uuid.UUID {
 	if os.Getenv("AUTH_DISABLED") == "true" {
@@ -1752,6 +1771,24 @@ func (s *Server) handleUpdateMember(w http.ResponseWriter, r *http.Request) {
 	}
 	if input.Source != "local" && input.Source != "sso" {
 		http.Error(w, "source must be local or sso", http.StatusBadRequest)
+		return
+	}
+	// Verify the target user belongs to this team before modifying their phone.
+	members, err := s.cfg.GetTeamMembers(r.Context(), teamID)
+	if err != nil {
+		log.Printf("handleUpdateMember: get members: %v", err)
+		http.Error(w, "failed to verify team membership", http.StatusInternalServerError)
+		return
+	}
+	isMember := false
+	for _, m := range members {
+		if m.ID == userID {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		http.Error(w, "user is not a member of this team", http.StatusUnprocessableEntity)
 		return
 	}
 	if err := s.cfg.UpdateMemberPhone(r.Context(), userID, input.Source, input.Phone); err != nil {
@@ -1868,8 +1905,8 @@ func (s *Server) handleCreateOverride(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid team ID", http.StatusBadRequest)
 		return
 	}
-	// responders and admins can create overrides for themselves/others
-	if !s.requireTeamAccess(r, teamID) {
+	// responders and admins can create overrides; viewers cannot
+	if !s.requireTeamResponder(r, teamID) {
 		writeForbidden(w)
 		return
 	}
@@ -1886,6 +1923,25 @@ func (s *Server) handleCreateOverride(w http.ResponseWriter, r *http.Request) {
 	userID, err := uuid.Parse(input.UserID)
 	if err != nil {
 		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+	// Verify the override target is a member of this team — prevents an admin
+	// from pointing an override at a user ID that belongs to a different team.
+	members, err := s.cfg.GetTeamMembers(r.Context(), teamID)
+	if err != nil {
+		log.Printf("handleCreateOverride: get members: %v", err)
+		http.Error(w, "failed to verify team membership", http.StatusInternalServerError)
+		return
+	}
+	isMember := false
+	for _, m := range members {
+		if m.ID == userID {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		http.Error(w, "user is not a member of this team", http.StatusUnprocessableEntity)
 		return
 	}
 	startAt, err := time.Parse(time.RFC3339, input.StartAt)

--- a/internal/validate/url.go
+++ b/internal/validate/url.go
@@ -15,14 +15,60 @@
 package validate
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
 	"strings"
+	"time"
 )
 
+// privateNets lists CIDR ranges that must never be the target of an outbound request.
+var privateNets = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+		"127.0.0.0/8", "169.254.0.0/16",
+		"::1/128", "fc00::/7", "fe80::/10",
+		"100.64.0.0/10", // Carrier-grade NAT
+		"224.0.0.0/4",   // Multicast
+		"240.0.0.0/4",   // Reserved
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// resolveHost is the DNS lookup function used by EndpointURL. Tests may
+// override this variable to avoid real network calls.
+var resolveHost = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// isPrivateIP returns true if ip falls within any private or reserved range.
+func isPrivateIP(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.Equal(net.IPv4zero) || ip.Equal(net.IPv6unspecified) {
+		return true
+	}
+	for _, n := range privateNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // EndpointURL rejects URLs that could be used for SSRF attacks.
-// Only public http/https URLs are allowed — no private IP ranges, no localhost.
+// Only public http/https URLs are allowed. For hostnames, DNS is resolved at
+// validation time and every returned address is checked against
+// private/loopback/link-local/reserved ranges.
 func EndpointURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -32,48 +78,44 @@ func EndpointURL(rawURL string) error {
 		return fmt.Errorf("only http and https schemes are allowed")
 	}
 	host := u.Hostname()
-	ip := net.ParseIP(host)
-	if ip == nil {
-		// DNS name — block known internal hostname patterns.
-		lower := strings.ToLower(host)
-		blocked := []string{
-			"localhost",
-			"localhost.localdomain",
-			"metadata",        // GCP/AWS metadata short name in some configs
-			"metadata.google",
-		}
-		for _, b := range blocked {
-			if lower == b {
-				return fmt.Errorf("private hostnames are not allowed")
-			}
-		}
-		if strings.HasSuffix(lower, ".local") ||
-			strings.HasSuffix(lower, ".internal") ||
-			strings.HasSuffix(lower, ".localdomain") {
-			return fmt.Errorf("private hostnames are not allowed")
+
+	// Literal IP — check directly.
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("private IP addresses are not allowed")
 		}
 		return nil
 	}
-	// Block 0.0.0.0 explicitly — maps to all interfaces (loopback on Linux).
-	if ip.Equal(net.IPv4zero) || ip.Equal(net.IPv6unspecified) {
-		return fmt.Errorf("private IP addresses are not allowed")
-	}
-	// Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1).
-	if v4 := ip.To4(); v4 != nil {
-		ip = v4
-	}
-	// Block RFC 1918, loopback, link-local, and metadata service ranges.
-	privateRanges := []string{
-		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
-		"127.0.0.0/8", "169.254.0.0/16", "::1/128", "fc00::/7",
-	}
-	for _, cidr := range privateRanges {
-		_, network, err := net.ParseCIDR(cidr)
-		if err != nil {
-			continue
+
+	// DNS name — block known internal hostname patterns first (fast path).
+	lower := strings.ToLower(host)
+	for _, b := range []string{"localhost", "localhost.localdomain", "metadata", "metadata.google"} {
+		if lower == b {
+			return fmt.Errorf("private hostnames are not allowed")
 		}
-		if network.Contains(ip) {
-			return fmt.Errorf("private IP addresses are not allowed")
+	}
+	if strings.HasSuffix(lower, ".local") ||
+		strings.HasSuffix(lower, ".internal") ||
+		strings.HasSuffix(lower, ".localdomain") {
+		return fmt.Errorf("private hostnames are not allowed")
+	}
+
+	// Resolve the hostname and verify every returned address is public.
+	// A 3-second timeout prevents hanging on slow/unresponsive DNS.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	addrs, err := resolveHost(ctx, host)
+	if err != nil {
+		// Unresolvable hostname — reject; we cannot verify it is safe.
+		return fmt.Errorf("could not resolve hostname")
+	}
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			return fmt.Errorf("unexpected address from DNS resolution")
+		}
+		if isPrivateIP(ip) {
+			return fmt.Errorf("hostname resolves to a private address")
 		}
 	}
 	return nil

--- a/internal/validate/url.go
+++ b/internal/validate/url.go
@@ -26,12 +26,24 @@ import (
 // privateNets lists CIDR ranges that must never be the target of an outbound request.
 var privateNets = func() []*net.IPNet {
 	cidrs := []string{
+		// RFC 1918 — private
 		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+		// Loopback and link-local
 		"127.0.0.0/8", "169.254.0.0/16",
+		// IPv6 loopback, ULA, link-local
 		"::1/128", "fc00::/7", "fe80::/10",
-		"100.64.0.0/10", // Carrier-grade NAT
-		"224.0.0.0/4",   // Multicast
-		"240.0.0.0/4",   // Reserved
+		// Carrier-grade NAT (RFC 6598)
+		"100.64.0.0/10",
+		// Multicast and reserved
+		"224.0.0.0/4", "240.0.0.0/4",
+		// IANA special-purpose (protocol assignments, RFC 5736)
+		"192.0.0.0/24",
+		// Benchmarking (RFC 2544)
+		"198.18.0.0/15",
+		// RFC 5737 documentation ranges (TEST-NET-1/2/3)
+		"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24",
+		// IPv6 documentation (RFC 3849)
+		"2001:db8::/32",
 	}
 	nets := make([]*net.IPNet, 0, len(cidrs))
 	for _, cidr := range cidrs {

--- a/internal/validate/url_test.go
+++ b/internal/validate/url_test.go
@@ -1,10 +1,20 @@
 package validate
 
 import (
+	"context"
 	"testing"
 )
 
 func TestEndpointURL_Allowed(t *testing.T) {
+	// Stub DNS to return a known public IP so tests are not network-dependent.
+	// The real resolver is used in production; the security logic under test is
+	// the IP-range checking and hostname-pattern blocking, not DNS itself.
+	orig := resolveHost
+	resolveHost = func(_ context.Context, _ string) ([]string, error) {
+		return []string{"203.0.113.1"}, nil // TEST-NET-3 — documentation range, public
+	}
+	defer func() { resolveHost = orig }()
+
 	cases := []string{
 		"https://prometheus.example.com",
 		"http://grafana.example.com:3000",

--- a/internal/validate/url_test.go
+++ b/internal/validate/url_test.go
@@ -11,7 +11,7 @@ func TestEndpointURL_Allowed(t *testing.T) {
 	// the IP-range checking and hostname-pattern blocking, not DNS itself.
 	orig := resolveHost
 	resolveHost = func(_ context.Context, _ string) ([]string, error) {
-		return []string{"203.0.113.1"}, nil // TEST-NET-3 — documentation range, public
+		return []string{"8.8.8.8"}, nil // Google Public DNS — genuinely public, not in any reserved range
 	}
 	defer func() { resolveHost = orig }()
 


### PR DESCRIPTION
## Summary

Six security fixes from an external audit, plus integration test repairs.

**Fixes in this PR:**

| Issue | Fix |
|---|---|
| #12 — Config endpoints exposed webhook secret to non-admins | GET/PUT config now require admin role; webhook_secret removed from response |
| #13 — SSRF protection skipped DNS resolution | EndpointURL resolves DNS at validation time, checks all returned IPs against private/reserved ranges |
| #14 — No webhook body size limit | MaxBytesReader(1 MB) added before io.ReadAll |
| #15 — X-Forwarded-For trusted unconditionally | XFF only trusted when RemoteAddr is private/loopback (in-cluster proxy) |
| #16 — Override target not verified as team member | GetTeamMembers check before CreateOverride; cross-team user → 422 |
| (unissued) — Phone update not scoped to team | Same membership check before UpdateMemberPhone |

**Also fixed:**
- Viewers could create on-call overrides — `requireTeamResponder` added, viewers now get 403
- Viewer denial regression test added

**Integration test repairs (tests were broken before this PR):**
- `webhookLimiter` and `cfg` were nil in test server — nil pointer panics on webhook calls
- Config test used `prometheus.example.com` / `loki.example.com` which now fail DNS validation — removed fake endpoints
- Webhook security test expected 403 for wrong-secret cases but handler returns 401 — fixed expectations

**Deferred (separate issues):**
- #17 — SSRF DNS rebinding via transport (custom DialContext + CheckRedirect)
- #18 — XFF still spoofable in k8s with misconfigured ingress (configurable trusted-proxy CIDRs)

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./...` — all pass
- [ ] `go test -tags integration ./cmd/server/` — requires local Postgres + Redis
- [ ] Verify config GET no longer includes `webhook_secret` in response
- [ ] Verify viewer role gets 403 on override creation
- [ ] Verify cross-team user_id returns 422 on override creation and phone update

/cc @fatkobra — would appreciate a second look, especially on the requireTeamResponder logic and the integration test repairs