### PR TITLE
fix: return 404 when incident does not exist

### DIFF
--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -659,3 +659,25 @@ func TestE2E_WebhookSecurity(t *testing.T) {
 		})
 	}
 }
+
+// TestE2E_GetIncident_NotFoundReturns404 verifies that requesting a
+// non-existent incident ID returns HTTP 404 instead of dereferencing a nil
+// incident.
+func TestE2E_GetIncident_NotFoundReturns404(t *testing.T) {
+	env := newE2EEnv(t)
+
+	missingID := uuid.New()
+
+	req := httptest.NewRequest(
+		"GET",
+		fmt.Sprintf("/api/v1/teams/%s/incidents/%s", env.kongTeam.ID, missingID),
+		nil,
+	)
+	req.AddCookie(env.kongCookie)
+
+	resp := env.do(req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("get missing incident: got %d, want 404\nbody: %s", resp.Code, resp.Body)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/redis/go-redis/v9"
-	"golang.org/x/time/rate"
 	"github.com/wachd/wachd/internal/auth"
 	"github.com/wachd/wachd/internal/license"
 	"github.com/wachd/wachd/internal/notify"
@@ -45,6 +44,7 @@ import (
 	"github.com/wachd/wachd/internal/queue"
 	"github.com/wachd/wachd/internal/store"
 	"github.com/wachd/wachd/internal/validate"
+	"golang.org/x/time/rate"
 )
 
 type Server struct {
@@ -115,16 +115,16 @@ type GrafanaWebhook struct {
 // DatadogWebhook represents a Datadog webhook alert payload.
 // See: https://docs.datadoghq.com/integrations/webhooks/
 type DatadogWebhook struct {
-	ID               string `json:"id"`
-	Title            string `json:"title"`
-	Body             string `json:"body"`
-	AlertType        string `json:"alert_type"`        // error | warning | info | success
-	AlertTransition  string `json:"alert_transition"`  // Triggered | Recovered | Re-Triggered | Resolved
-	Priority         string `json:"priority"`          // normal | low
-	Hostname         string `json:"hostname"`
-	Tags             string `json:"tags"`
-	OrgID            int64  `json:"org_id"`
-	AlertID          int64  `json:"alert_id"`
+	ID              string `json:"id"`
+	Title           string `json:"title"`
+	Body            string `json:"body"`
+	AlertType       string `json:"alert_type"`       // error | warning | info | success
+	AlertTransition string `json:"alert_transition"` // Triggered | Recovered | Re-Triggered | Resolved
+	Priority        string `json:"priority"`         // normal | low
+	Hostname        string `json:"hostname"`
+	Tags            string `json:"tags"`
+	OrgID           int64  `json:"org_id"`
+	AlertID         int64  `json:"alert_id"`
 }
 
 // parseWebhookPayload detects the source format and extracts a normalised
@@ -660,7 +660,7 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"status": "accepted",
+		"status":      "accepted",
 		"incident_id": incident.ID,
 	})
 }
@@ -728,6 +728,10 @@ func (s *Server) handleGetIncident(w http.ResponseWriter, r *http.Request) {
 	incident, err := s.db.GetIncident(r.Context(), teamID, incidentID)
 	if err != nil {
 		log.Printf("Failed to get incident: %v", err)
+		http.Error(w, "Failed to get incident", http.StatusInternalServerError)
+		return
+	}
+	if incident == nil {
 		http.Error(w, "Incident not found", http.StatusNotFound)
 		return
 	}
@@ -1281,7 +1285,7 @@ type teamConfigPublic struct {
 type teamConfigInput struct {
 	SlackWebhookURL    *string  `json:"slack_webhook_url"`
 	SlackChannel       *string  `json:"slack_channel"`
-	GitHubToken        string   `json:"github_token"`  // plaintext; encrypted before storing
+	GitHubToken        string   `json:"github_token"` // plaintext; encrypted before storing
 	GitHubRepos        []string `json:"github_repos"`
 	PrometheusEndpoint *string  `json:"prometheus_endpoint"`
 	LokiEndpoint       *string  `json:"loki_endpoint"`
@@ -2016,8 +2020,8 @@ func bootstrapAdmin(ctx context.Context, db *store.DB) error {
 		"admin@wachd.local",
 		"Wachd Admin",
 		hash,
-		true,  // isSuperAdmin
-		true,  // forcePasswordChange — must change on first login
+		true, // isSuperAdmin
+		true, // forcePasswordChange — must change on first login
 	)
 	if err != nil {
 		return fmt.Errorf("create bootstrap admin: %w", err)
@@ -2026,8 +2030,8 @@ func bootstrapAdmin(ctx context.Context, db *store.DB) error {
 	log.Println("╔════════════════════════════════════════════════╗")
 	log.Println("║      WACHD — BOOTSTRAP ADMIN CREATED          ║")
 	log.Println("╠════════════════════════════════════════════════╣")
-	log.Printf( "║  Username: %-35s║", "wachd_admin")
-	log.Printf( "║  Password: %-35s║", password)
+	log.Printf("║  Username: %-35s║", "wachd_admin")
+	log.Printf("║  Password: %-35s║", password)
 	log.Println("╠════════════════════════════════════════════════╣")
 	log.Println("║  ⚠  Change this password immediately!         ║")
 	log.Println("║  POST /auth/local/login  (then /change-password)║")
@@ -2039,11 +2043,11 @@ func bootstrapAdmin(ctx context.Context, db *store.DB) error {
 // generateAdminPassword returns a random 16-character password that satisfies
 // the default policy (upper, lower, digit, special).
 func generateAdminPassword() (string, error) {
-	const upper   = "ABCDEFGHJKLMNPQRSTUVWXYZ"
-	const lower   = "abcdefghjkmnpqrstuvwxyz"
-	const digits  = "23456789"
+	const upper = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+	const lower = "abcdefghjkmnpqrstuvwxyz"
+	const digits = "23456789"
 	const special = "!@#$%^&*"
-	const all     = upper + lower + digits + special
+	const all = upper + lower + digits + special
 
 	// Guarantee at least one of each required class
 	pick := func(charset string) (byte, error) {
@@ -2152,12 +2156,12 @@ func bootstrapFirstTeam(db *store.DB) error {
 	log.Println("╔══════════════════════════════════════════════════════╗")
 	log.Println("║              WACHD — FIRST RUN SETUP                ║")
 	log.Println("╠══════════════════════════════════════════════════════╣")
-	log.Printf( "║  Team ID:       %-36s  ║", team.ID)
-	log.Printf( "║  Webhook secret: %-35s  ║", secret)
+	log.Printf("║  Team ID:       %-36s  ║", team.ID)
+	log.Printf("║  Webhook secret: %-35s  ║", secret)
 	log.Println("╠══════════════════════════════════════════════════════╣")
 	log.Println("║  Send alerts to:                                     ║")
-	log.Printf( "║  POST /api/v1/webhook/%s/  ║", team.ID)
-	log.Printf( "║  Header or path secret: %-28s  ║", secret)
+	log.Printf("║  POST /api/v1/webhook/%s/  ║", team.ID)
+	log.Printf("║  Header or path secret: %-28s  ║", secret)
 	log.Println("╚══════════════════════════════════════════════════════╝")
 
 	return nil


### PR DESCRIPTION
## Summary

Closes #20 

Fixes missing incident retrieval so the server returns 404 instead of dereferencing a nil incident.

- distinguish store errors from "not found" in `handleGetIncident`
- return 500 on real DB errors
- return 404 when `GetIncident` returns nil
- add an e2e regression test for GET on a non-existent incident ID


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

- gofmt -w cmd/server/main.go cmd/server/e2e_integration_test.go
- go test ./...
- go vet ./...
- go build ./...


- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

<!-- Closes #20  -->
