### PR TITLE
fix(security): add SSRF-safe HTTP transport

### DIFF
--- a/internal/safehttp/safehttp.go
+++ b/internal/safehttp/safehttp.go
@@ -1,0 +1,237 @@
+package safehttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/wachd/wachd/internal/validate"
+)
+
+// Resolver is the DNS lookup surface used by the safe dialer.
+// It is intentionally tiny so tests can inject deterministic DNS answers.
+type Resolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+type config struct {
+	resolver    Resolver
+	dialContext func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Option configures the safe HTTP transport.
+type Option func(*config)
+
+// WithResolver overrides DNS resolution. It is primarily useful for tests.
+func WithResolver(resolver Resolver) Option {
+	return func(cfg *config) {
+		if resolver != nil {
+			cfg.resolver = resolver
+		}
+	}
+}
+
+// WithDialContext overrides the final TCP dial function.
+// It is primarily useful for tests.
+func WithDialContext(dialContext func(ctx context.Context, network, address string) (net.Conn, error)) Option {
+	return func(cfg *config) {
+		if dialContext != nil {
+			cfg.dialContext = dialContext
+		}
+	}
+}
+
+// NewTransport returns an http.Transport that prevents DNS-rebinding SSRF.
+//
+// The dialer resolves the request hostname, validates every returned IP, and
+// then dials one of the already-validated IPs directly. This avoids the common
+// TOCTOU bug where code validates one DNS lookup but then hands the original
+// hostname back to net.Dial, causing a second lookup at connection time.
+func NewTransport(opts ...Option) *http.Transport {
+	netDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	cfg := &config{
+		resolver:    net.DefaultResolver,
+		dialContext: netDialer.DialContext,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.DialContext = (&safeDialer{
+		resolver:    cfg.resolver,
+		dialContext: cfg.dialContext,
+	}).DialContext
+
+	return base
+}
+
+// NewRoundTripper returns a RoundTripper that validates the request URL and
+// uses NewTransport for DNS-rebinding-safe dials.
+func NewRoundTripper(opts ...Option) http.RoundTripper {
+	return &validatingRoundTripper{
+		base: NewTransport(opts...),
+	}
+}
+
+// CollectorClient returns a hardened client for collector GET/query traffic.
+//
+// Redirects are allowed only when each redirect target also passes URL
+// validation. The redirected request still uses the safe transport.
+func CollectorClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     NewRoundTripper(),
+		CheckRedirect: ValidateRedirect,
+	}
+}
+
+// WebhookClient returns a hardened client for webhook POST traffic.
+//
+// Webhook-style POSTs should not follow redirects at all. Returning
+// http.ErrUseLastResponse makes net/http return the 3xx response to the caller
+// without following it.
+func WebhookClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     NewRoundTripper(),
+		CheckRedirect: DenyRedirect,
+	}
+}
+
+// ValidateRedirect rejects redirects to URLs blocked by validate.EndpointURL.
+func ValidateRedirect(req *http.Request, via []*http.Request) error {
+	if req == nil || req.URL == nil {
+		return errors.New("redirect target is missing URL")
+	}
+
+	if err := validate.EndpointURL(req.URL.String()); err != nil {
+		return fmt.Errorf("blocked redirect target: %w", err)
+	}
+
+	return nil
+}
+
+// DenyRedirect disables redirects for webhook-style clients.
+func DenyRedirect(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+type validatingRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (v *validatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil || req.URL == nil {
+		return nil, errors.New("request is missing URL")
+	}
+
+	if err := validate.EndpointURL(req.URL.String()); err != nil {
+		return nil, err
+	}
+
+	return v.base.RoundTrip(req)
+}
+
+type safeDialer struct {
+	resolver    Resolver
+	dialContext func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+func (d *safeDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dial address %q: %w", address, err)
+	}
+
+	ips, err := d.resolve(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no IP addresses resolved for %q", host)
+	}
+
+	for _, ip := range ips {
+		if isBlockedIP(ip) {
+			return nil, fmt.Errorf("blocked private or local IP address %s for host %q", ip.String(), host)
+		}
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		if !compatibleWithNetwork(network, ip) {
+			continue
+		}
+
+		conn, err := d.dialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	return nil, fmt.Errorf("no resolved IPs for %q were compatible with network %q", host, network)
+}
+
+func (d *safeDialer) resolve(ctx context.Context, host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{normalizeIP(ip)}, nil
+	}
+
+	addrs, err := d.resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", host, err)
+	}
+
+	ips := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.IP == nil {
+			continue
+		}
+		ips = append(ips, normalizeIP(addr.IP))
+	}
+
+	return ips, nil
+}
+
+func normalizeIP(ip net.IP) net.IP {
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+
+	return ip
+}
+
+func compatibleWithNetwork(network string, ip net.IP) bool {
+	switch network {
+	case "tcp4":
+		return ip.To4() != nil
+	case "tcp6":
+		return ip.To4() == nil
+	default:
+		return true
+	}
+}
+
+func isBlockedIP(ip net.IP) bool {
+	ip = normalizeIP(ip)
+
+	return ip.IsUnspecified() ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast()
+}

--- a/internal/safehttp/safehttp_test.go
+++ b/internal/safehttp/safehttp_test.go
@@ -1,0 +1,147 @@
+package safehttp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type fakeResolver struct {
+	addrs []net.IPAddr
+	err   error
+}
+
+func (f fakeResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return f.addrs, f.err
+}
+
+func TestDialContextRejectsPrivateDNSResolution(t *testing.T) {
+	dialCalled := false
+
+	transport := NewTransport(
+		WithResolver(fakeResolver{
+			addrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}},
+		}),
+		WithDialContext(func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCalled = true
+			return nil, errors.New("should not dial")
+		}),
+	)
+
+	_, err := transport.DialContext(context.Background(), "tcp", "example.com:443")
+	if err == nil {
+		t.Fatal("expected private DNS result to be rejected")
+	}
+	if !strings.Contains(err.Error(), "blocked private or local IP address") {
+		t.Fatalf("expected private IP error, got: %v", err)
+	}
+	if dialCalled {
+		t.Fatal("dial should not be called after private DNS result")
+	}
+}
+
+func TestDialContextRejectsMixedPublicAndPrivateDNSResults(t *testing.T) {
+	dialCalled := false
+
+	transport := NewTransport(
+		WithResolver(fakeResolver{
+			addrs: []net.IPAddr{
+				{IP: net.ParseIP("203.0.113.10")},
+				{IP: net.ParseIP("169.254.169.254")},
+			},
+		}),
+		WithDialContext(func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCalled = true
+			return nil, errors.New("should not dial")
+		}),
+	)
+
+	_, err := transport.DialContext(context.Background(), "tcp", "example.com:443")
+	if err == nil {
+		t.Fatal("expected mixed public/private DNS results to be rejected")
+	}
+	if !strings.Contains(err.Error(), "169.254.169.254") {
+		t.Fatalf("expected error to mention blocked metadata IP, got: %v", err)
+	}
+	if dialCalled {
+		t.Fatal("dial should not be called when any resolved IP is blocked")
+	}
+}
+
+func TestDialContextDialsValidatedResolvedIPNotOriginalHostname(t *testing.T) {
+	expectedErr := errors.New("stop after recording dial address")
+	var dialedAddress string
+
+	transport := NewTransport(
+		WithResolver(fakeResolver{
+			addrs: []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}},
+		}),
+		WithDialContext(func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialedAddress = address
+			return nil, expectedErr
+		}),
+	)
+
+	_, err := transport.DialContext(context.Background(), "tcp", "example.com:443")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected fake dial error, got: %v", err)
+	}
+
+	if dialedAddress != "203.0.113.10:443" {
+		t.Fatalf("expected dial to use resolved IP, got %q", dialedAddress)
+	}
+}
+
+func TestRoundTripRejectsPrivateURLBeforeNetworkDial(t *testing.T) {
+	dialCalled := false
+
+	roundTripper := NewRoundTripper(
+		WithDialContext(func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCalled = true
+			return nil, errors.New("should not dial")
+		}),
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/admin", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	_, err = roundTripper.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected private request URL to be rejected")
+	}
+	if dialCalled {
+		t.Fatal("dial should not be called for blocked request URL")
+	}
+}
+
+func TestValidateRedirectRejectsPrivateRedirectTarget(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	err = ValidateRedirect(req, nil)
+	if err == nil {
+		t.Fatal("expected private redirect target to be rejected")
+	}
+	if !strings.Contains(err.Error(), "blocked redirect target") {
+		t.Fatalf("expected redirect error, got: %v", err)
+	}
+}
+
+func TestDenyRedirectStopsRedirects(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/redirected", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	err = DenyRedirect(req, nil)
+	if !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("expected http.ErrUseLastResponse, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Part of #17.

This adds a centralized `internal/safehttp` package for outbound HTTP clients.

The helper protects against the two transport-level SSRF gaps described in #17:

- DNS rebinding between config validation and actual connection time
- unvalidated redirects to private/internal targets

## What changed

- Added `safehttp.NewTransport()`.
  - Resolves the request hostname inside `DialContext`.
  - Validates every resolved IP.
  - Dials the already-validated IP directly instead of handing the hostname back to `net.Dial`.
- Added `safehttp.NewRoundTripper()`.
  - Validates the initial request URL with the existing `validate.EndpointURL`.
  - Uses the safe transport for the actual network connection.
- Added client helpers:
  - `CollectorClient()` validates redirect targets before following them.
  - `WebhookClient()` disables redirects for webhook-style POSTs.
- Added tests for:
  - private DNS results
  - mixed public/private DNS results
  - dialing the validated IP instead of the original hostname
  - private URL rejection before network dial
  - redirect validation
  - webhook redirect disabling

## Why

`validate.EndpointURL` protects config-save-time validation, but it does not protect the actual connection if DNS changes later.

The important part is avoiding the TOCTOU pattern:

1. resolve hostname;
2. validate the resolved IP;
3. accidentally dial the hostname again.

This helper validates and then dials the same resolved IP.



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

```bash
gofmt -w internal/safehttp/safehttp.go internal/safehttp/safehttp_test.go
go test ./internal/safehttp
go test ./...
make test
go build ./...
go vet ./...
```


- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

Part of #17 
