### PR TITLE
fix(security): use safe HTTP clients for outbound calls

### DIFF
--- a/internal/collector/dynatrace.go
+++ b/internal/collector/dynatrace.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/wachd/wachd/internal/safehttp"
 	"io"
 	"net/http"
 	"net/url"
@@ -38,22 +39,30 @@ type DynatraceCollector struct {
 
 // DytraceProblem represents a Dynatrace problem/anomaly.
 type DytraceProblem struct {
-	ID           string    `json:"problemId"`
-	Title        string    `json:"title"`
-	Status       string    `json:"status"` // OPEN | CLOSED
-	Severity     string    `json:"severityLevel"`
-	StartTime    time.Time `json:"startTime"`
-	AffectedEntities []string `json:"affectedEntityNames"`
+	ID               string    `json:"problemId"`
+	Title            string    `json:"title"`
+	Status           string    `json:"status"` // OPEN | CLOSED
+	Severity         string    `json:"severityLevel"`
+	StartTime        time.Time `json:"startTime"`
+	AffectedEntities []string  `json:"affectedEntityNames"`
 }
 
 // NewDynatraceCollector creates a Dynatrace collector.
 // endpoint: your environment URL, e.g. https://abc12345.live.dynatrace.com
 // token: API token with problems.read, logs.read, metrics.read, entities.read
 func NewDynatraceCollector(endpoint, token string) *DynatraceCollector {
+	return newDynatraceCollectorWithClient(endpoint, token, safehttp.CollectorClient(30*time.Second))
+}
+
+func newDynatraceCollectorWithClient(endpoint, token string, client *http.Client) *DynatraceCollector {
+	if client == nil {
+		client = safehttp.CollectorClient(30 * time.Second)
+	}
+
 	return &DynatraceCollector{
 		endpoint: endpoint,
 		token:    token,
-		client:   &http.Client{Timeout: 30 * time.Second},
+		client:   client,
 	}
 }
 

--- a/internal/collector/dynatrace_test.go
+++ b/internal/collector/dynatrace_test.go
@@ -30,6 +30,19 @@ func TestNewDynatraceCollector(t *testing.T) {
 	}
 }
 
+func TestNewDynatraceCollectorUsesSafeHTTPClient(t *testing.T) {
+	c := NewDynatraceCollector("https://abc.live.dynatrace.com", "dt-token")
+	if c.client == nil {
+		t.Fatal("expected client to be configured")
+	}
+	if c.client.Transport == nil {
+		t.Fatal("expected safe transport to be configured")
+	}
+	if c.client.CheckRedirect == nil {
+		t.Fatal("expected redirect validation to be configured")
+	}
+}
+
 func TestDynatraceCollector_FetchProblems_MissingConfig(t *testing.T) {
 	tests := []struct {
 		endpoint string
@@ -74,7 +87,7 @@ func TestDynatraceCollector_FetchProblems_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	problems, err := c.FetchProblems(context.Background(), "checkout-api", start, 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -99,7 +112,7 @@ func TestDynatraceCollector_FetchProblems_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	_, err := c.FetchProblems(context.Background(), "svc", time.Now().Add(-time.Hour), 10)
 	if err == nil {
 		t.Error("expected error for 500 response")
@@ -132,7 +145,7 @@ func TestDynatraceCollector_FetchLogs_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	logs, err := c.FetchLogs(context.Background(), "checkout-api", ts.Add(-time.Minute), ts.Add(time.Minute), 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -167,7 +180,7 @@ func TestDynatraceCollector_FetchLogs_NilAttributes(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	logs, err := c.FetchLogs(context.Background(), "svc", time.Now().Add(-time.Hour), time.Now(), 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -212,7 +225,7 @@ func TestDynatraceCollector_FetchMetrics_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	points, err := c.FetchMetrics(context.Background(), "checkout-api",
 		"builtin:service.errors.total.rate", ts.Add(-time.Minute), ts.Add(2*time.Minute))
 	if err != nil {
@@ -249,7 +262,7 @@ func TestDynatraceCollector_FetchMetrics_MismatchedTimestampsValues(t *testing.T
 	}))
 	defer srv.Close()
 
-	c := NewDynatraceCollector(srv.URL, "dt-token")
+	c := newDynatraceCollectorWithClient(srv.URL, "dt-token", srv.Client())
 	points, err := c.FetchMetrics(context.Background(), "svc", "builtin:error.rate",
 		time.Now().Add(-time.Hour), time.Now())
 	if err != nil {

--- a/internal/collector/logs.go
+++ b/internal/collector/logs.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/wachd/wachd/internal/safehttp"
 	"io"
 	"net/http"
 	"net/url"
@@ -51,13 +52,19 @@ type LokiResponse struct {
 	} `json:"data"`
 }
 
-// NewLogsCollector creates a new Loki logs collector
+// NewLogsCollector creates a new Loki logs collector.
 func NewLogsCollector(endpoint string) *LogsCollector {
+	return newLogsCollectorWithClient(endpoint, safehttp.CollectorClient(30*time.Second))
+}
+
+func newLogsCollectorWithClient(endpoint string, client *http.Client) *LogsCollector {
+	if client == nil {
+		client = safehttp.CollectorClient(30 * time.Second)
+	}
+
 	return &LogsCollector{
 		endpoint: endpoint,
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		client:   client,
 	}
 }
 

--- a/internal/collector/logs_test.go
+++ b/internal/collector/logs_test.go
@@ -31,6 +31,19 @@ func TestNewLogsCollector(t *testing.T) {
 	}
 }
 
+func TestNewLogsCollectorUsesSafeHTTPClient(t *testing.T) {
+	c := NewLogsCollector("https://loki.example.com")
+	if c.client == nil {
+		t.Fatal("expected client to be configured")
+	}
+	if c.client.Transport == nil {
+		t.Fatal("expected safe transport to be configured")
+	}
+	if c.client.CheckRedirect == nil {
+		t.Fatal("expected redirect validation to be configured")
+	}
+}
+
 func TestLogsCollector_FetchLogs_NoEndpoint(t *testing.T) {
 	c := NewLogsCollector("")
 	_, err := c.FetchLogs(context.Background(), `{app="api"}`, time.Now().Add(-time.Hour), time.Now(), 100)
@@ -67,7 +80,7 @@ func TestLogsCollector_FetchLogs_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	logs, err := c.FetchLogs(context.Background(), `{service="api"}`, ts.Add(-time.Minute), ts.Add(time.Minute), 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -89,7 +102,7 @@ func TestLogsCollector_FetchLogs_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	_, err := c.FetchLogs(context.Background(), `{app="x"}`, time.Now().Add(-time.Hour), time.Now(), 10)
 	if err == nil {
 		t.Error("expected error for 500 response")
@@ -103,7 +116,7 @@ func TestLogsCollector_FetchLogs_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	_, err := c.FetchLogs(context.Background(), `{app="x"}`, time.Now().Add(-time.Hour), time.Now(), 10)
 	if err == nil {
 		t.Error("expected error for invalid JSON")
@@ -120,7 +133,7 @@ func TestLogsCollector_FetchLogs_EmptyResult(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	logs, err := c.FetchLogs(context.Background(), `{app="x"}`, time.Now().Add(-time.Hour), time.Now(), 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -149,7 +162,7 @@ func TestLogsCollector_FetchLogs_ShortValueEntry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	logs, err := c.FetchLogs(context.Background(), `{app="x"}`, time.Now().Add(-time.Hour), time.Now(), 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -185,7 +198,7 @@ func TestLogsCollector_FetchLogs_NanosecondTimestamp(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	logs, err := c.FetchLogs(context.Background(), `{service="api"}`,
 		expectedTime.Add(-time.Minute), expectedTime.Add(time.Minute), 100)
 	if err != nil {
@@ -221,7 +234,7 @@ func TestLogsCollector_FetchLogs_MalformedTimestampSkipped(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	logs, err := c.FetchLogs(context.Background(), `{app="x"}`,
 		time.Now().Add(-time.Hour), time.Now(), 10)
 	if err != nil {
@@ -247,7 +260,7 @@ func TestLogsCollector_FetchErrorLogs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewLogsCollector(srv.URL)
+	c := newLogsCollectorWithClient(srv.URL, srv.Client())
 	_, err := c.FetchErrorLogs(context.Background(), "checkout-api", time.Now().Add(-time.Hour), time.Now(), 50)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -17,11 +17,13 @@ package collector
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"github.com/wachd/wachd/internal/safehttp"
 )
 
 // MetricsCollector fetches metrics from Prometheus
@@ -36,15 +38,24 @@ type MetricPoint struct {
 	Labels    map[string]string `json:"labels"`
 }
 
-// NewMetricsCollector creates a new Prometheus metrics collector
+// NewMetricsCollector creates a new Prometheus metrics collector.
 func NewMetricsCollector(endpoint string) (*MetricsCollector, error) {
+	return newMetricsCollectorWithRoundTripper(endpoint, safehttp.NewRoundTripper())
+}
+
+func newMetricsCollectorWithRoundTripper(endpoint string, roundTripper http.RoundTripper) (*MetricsCollector, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("prometheus endpoint not configured")
 	}
 
-	client, err := api.NewClient(api.Config{
+	config := api.Config{
 		Address: endpoint,
-	})
+	}
+	if roundTripper != nil {
+		config.RoundTripper = roundTripper
+	}
+
+	client, err := api.NewClient(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus client: %w", err)
 	}

--- a/internal/collector/metrics_test.go
+++ b/internal/collector/metrics_test.go
@@ -87,7 +87,7 @@ func TestFetchMetricHistory_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := NewMetricsCollector(srv.URL)
+	c, err := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("NewMetricsCollector: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestFetchMetricHistory_MultipleStreams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	now := time.Now()
 	points, err := c.FetchMetricHistory(context.Background(), "q", now.Add(-time.Hour), now, time.Minute)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestFetchMetricHistory_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	now := time.Now()
 	_, err := c.FetchMetricHistory(context.Background(), "q", now.Add(-time.Hour), now, time.Minute)
 	if err == nil {
@@ -170,7 +170,7 @@ func TestFetchMetricHistory_UnexpectedResultType(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	now := time.Now()
 	_, err := c.FetchMetricHistory(context.Background(), "q", now.Add(-time.Hour), now, time.Minute)
 	if err == nil {
@@ -192,7 +192,7 @@ func TestFetchMetricHistory_EmptyMatrix(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	now := time.Now()
 	points, err := c.FetchMetricHistory(context.Background(), "q", now.Add(-time.Hour), now, time.Minute)
 	if err != nil {
@@ -213,7 +213,7 @@ func TestFetchCurrentValue_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	val, labels, err := c.FetchCurrentValue(context.Background(), "test_metric")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -240,7 +240,7 @@ func TestFetchCurrentValue_EmptyVector(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	_, _, err := c.FetchCurrentValue(context.Background(), "empty_metric")
 	if err == nil {
 		t.Error("expected error for empty vector result")
@@ -253,7 +253,7 @@ func TestFetchCurrentValue_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	_, _, err := c.FetchCurrentValue(context.Background(), "q")
 	if err == nil {
 		t.Error("expected error for server 500")
@@ -269,7 +269,7 @@ func TestFetchCurrentValue_UnexpectedResultType(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	_, _, err := c.FetchCurrentValue(context.Background(), "q")
 	if err == nil {
 		t.Error("expected error for non-vector result type")
@@ -292,7 +292,7 @@ func TestFetchErrorRate_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	points, err := c.FetchErrorRate(context.Background(), "checkout-api", 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -311,7 +311,7 @@ func TestFetchErrorRate_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewMetricsCollector(srv.URL)
+	c, _ := newMetricsCollectorWithRoundTripper(srv.URL, http.DefaultTransport)
 	_, err := c.FetchErrorRate(context.Background(), "api", time.Minute)
 	if err == nil {
 		t.Error("expected error for server error")

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -19,23 +19,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/safehttp"
+	"github.com/wachd/wachd/internal/store"
 	"net/http"
 	"time"
-
-	"github.com/wachd/wachd/internal/ai"
-	"github.com/wachd/wachd/internal/store"
 )
 
 // SlackNotifier sends notifications to Slack
 type SlackNotifier struct {
 	webhookURL string
 	channel    string
+	client     *http.Client
 }
 
 // SlackMessage represents a Slack webhook message
 type SlackMessage struct {
-	Channel string `json:"channel,omitempty"`
-	Text    string `json:"text"`
+	Channel string  `json:"channel,omitempty"`
+	Text    string  `json:"text"`
 	Blocks  []Block `json:"blocks,omitempty"`
 }
 
@@ -51,11 +52,20 @@ type Text struct {
 	Text string `json:"text"`
 }
 
-// NewSlackNotifier creates a new Slack notifier
+// NewSlackNotifier creates a new Slack notifier.
 func NewSlackNotifier(webhookURL, channel string) *SlackNotifier {
+	return newSlackNotifierWithClient(webhookURL, channel, safehttp.WebhookClient(10*time.Second))
+}
+
+func newSlackNotifierWithClient(webhookURL, channel string, client *http.Client) *SlackNotifier {
+	if client == nil {
+		client = safehttp.WebhookClient(10 * time.Second)
+	}
+
 	return &SlackNotifier{
 		webhookURL: webhookURL,
 		channel:    channel,
+		client:     client,
 	}
 }
 
@@ -160,11 +170,7 @@ func (s *SlackNotifier) sendMessage(ctx context.Context, message SlackMessage) e
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send Slack message: %w", err)
 	}

--- a/internal/notify/slack_email_test.go
+++ b/internal/notify/slack_email_test.go
@@ -16,15 +16,15 @@ package notify
 
 import (
 	"context"
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/safehttp"
+	"github.com/wachd/wachd/internal/store"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
-	"github.com/wachd/wachd/internal/ai"
-	"github.com/wachd/wachd/internal/store"
 )
 
 func makeTestIncident() *store.Incident {
@@ -82,7 +82,7 @@ func TestSlackNotifier_SendIncidentAlert_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	n := NewSlackNotifier(srv.URL, "#alerts")
+	n := newSlackNotifierWithClient(srv.URL, "#alerts", srv.Client())
 	err := n.SendIncidentAlert(context.Background(), makeTestIncident(), makeTestMember(), makeTestAnalysis())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestSlackNotifier_SendIncidentAlert_NoAnalysis(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	n := NewSlackNotifier(srv.URL, "#alerts")
+	n := newSlackNotifierWithClient(srv.URL, "#alerts", srv.Client())
 	err := n.SendIncidentAlert(context.Background(), makeTestIncident(), makeTestMember(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error with nil analysis: %v", err)
@@ -111,7 +111,7 @@ func TestSlackNotifier_SendIncidentAlert_NoMessage(t *testing.T) {
 	incident := makeTestIncident()
 	incident.Message = nil
 
-	n := NewSlackNotifier(srv.URL, "#alerts")
+	n := newSlackNotifierWithClient(srv.URL, "#alerts", srv.Client())
 	err := n.SendIncidentAlert(context.Background(), incident, makeTestMember(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error with nil message: %v", err)
@@ -128,7 +128,7 @@ func TestSlackNotifier_SendIncidentAlert_EmptyMessage(t *testing.T) {
 	empty := ""
 	incident.Message = &empty
 
-	n := NewSlackNotifier(srv.URL, "#alerts")
+	n := newSlackNotifierWithClient(srv.URL, "#alerts", srv.Client())
 	err := n.SendIncidentAlert(context.Background(), incident, makeTestMember(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error with empty message: %v", err)
@@ -149,10 +149,52 @@ func TestSlackNotifier_SendMessage_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	n := NewSlackNotifier(srv.URL, "#alerts")
+	n := newSlackNotifierWithClient(srv.URL, "#alerts", srv.Client())
 	err := n.SendIncidentAlert(context.Background(), makeTestIncident(), makeTestMember(), nil)
 	if err == nil {
 		t.Error("expected error for non-200 response")
+	}
+}
+
+func TestNewSlackNotifierUsesWebhookClient(t *testing.T) {
+	n := NewSlackNotifier("https://hooks.slack.com/services/test", "#alerts")
+	if n.client == nil {
+		t.Fatal("expected client to be configured")
+	}
+	if n.client.Transport == nil {
+		t.Fatal("expected safe transport to be configured")
+	}
+	if n.client.CheckRedirect == nil {
+		t.Fatal("expected redirect policy to be configured")
+	}
+}
+
+func TestSlackNotifierDoesNotFollowRedirects(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	client := &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: safehttp.DenyRedirect,
+	}
+
+	n := newSlackNotifierWithClient(redirector.URL, "#alerts", client)
+	err := n.SendTestMessage(context.Background())
+	if err == nil {
+		t.Fatal("expected redirect response to be treated as a Slack error")
+	}
+
+	if targetCalled {
+		t.Fatal("Slack webhook client should not follow redirects")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #17.

This wires the centralized `internal/safehttp` helper into the outbound HTTP callers identified in the issue.

## What changed

- Loki logs collector now uses `safehttp.CollectorClient`.
- Dynatrace collector now uses `safehttp.CollectorClient`.
- Prometheus metrics collector now passes `safehttp.NewRoundTripper()` into the Prometheus API client.
- Slack notifier now uses `safehttp.WebhookClient`.
- Collector redirects are allowed only when every redirect target passes URL validation.
- Slack webhook POSTs do not follow redirects.
- Tests were updated so local `httptest` servers use injected local test clients instead of the production SSRF-blocking client.

## Why

Config-time URL validation is not enough to prevent SSRF.

Without transport-level protection, a hostname can validate as public at save time and then resolve to a private IP at connection time. Redirects can also move an otherwise valid outbound request to a private or metadata-service target.

The safe transport resolves and validates IPs inside `DialContext`, then dials the already-validated IP directly.



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

```bash
gofmt -w \
  internal/collector/logs.go \
  internal/collector/dynatrace.go \
  internal/collector/metrics.go \
  internal/notify/slack.go \
  internal/collector/logs_test.go \
  internal/collector/dynatrace_test.go \
  internal/collector/metrics_test.go \
  internal/notify/slack_email_test.go
go test ./internal/safehttp ./internal/collector ./internal/notify
go test ./...
make test
go build ./...
go vet ./..
```

- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

Closes #17 
