### PR TITLE
docs: document trusted proxy CIDRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ PORT=8080
 # e.g. https://wachd.company.internal
 CORS_ORIGIN=http://localhost:3000
 
+# Trusted ingress/proxy CIDRs for webhook client IP extraction.
+# Empty means X-Forwarded-For is ignored and webhook rate limiting uses RemoteAddr.
+# Example: TRUSTED_PROXY_CIDRS=10.0.0.0/8,172.16.0.0/12
+TRUSTED_PROXY_CIDRS=
+
 # ── Database ──────────────────────────────────────────────────────────────────
 DATABASE_URL=postgres://wachd:wachd_dev_password@localhost:5432/wachd?sslmode=disable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Wachd uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Webhook client IP extraction now trusts `X-Forwarded-For` only from configured `TRUSTED_PROXY_CIDRS`. Existing ingress deployments with the default empty value will rate-limit by ingress/proxy IP until trusted proxy CIDRs are configured.
 - `sessions.RequireAuth` (cookie-only) replaced by `auth.BearerOrCookie` on all protected routes — existing browser sessions are unaffected.
 - `GET /auth/me` response extended with `auth_type`, `is_superadmin`, and `force_password_change` fields.
 - Admin panel navigation adds **Teams**, **API Tokens**, and conditionally shows the **Admin** link in the top navigation bar for superadmin accounts.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Key settings in `.env`:
 DATABASE_URL=postgres://wachd:wachd@localhost:5432/wachd
 REDIS_URL=redis://localhost:6379
 
+# Trusted ingress/proxy CIDRs for webhook client IP extraction.
+# Empty means X-Forwarded-For is ignored and rate limiting uses RemoteAddr.
+TRUSTED_PROXY_CIDRS=
+
 # Analysis backend (Ollama for local, air-gapped deployments)
 AI_BACKEND=ollama
 OLLAMA_ENDPOINT=http://localhost:11434
@@ -127,6 +131,7 @@ make dev
 ```
 
 Opens:
+
 - API server on `http://localhost:8080`
 - Web dashboard on `http://localhost:3000`
 
@@ -302,6 +307,38 @@ The server **automatically creates all database tables on first startup** — no
 
 Paste that webhook URL into Grafana / Datadog alert routing and you are live.
 
+### Trusted proxy CIDRs
+
+Wachd rate-limits webhook requests by client IP.
+
+By default, `TRUSTED_PROXY_CIDRS` is empty. This is the safe default: Wachd ignores `X-Forwarded-For` and rate-limits by the direct `RemoteAddr`.
+
+If Wachd is deployed behind an ingress controller or load balancer and you want webhook rate limiting to use the original client IP, configure trusted proxy CIDRs.
+
+For local or direct environment configuration:
+
+```bash
+TRUSTED_PROXY_CIDRS=10.0.0.0/8,172.16.0.0/12
+```
+
+For Helm deployments:
+
+```yaml
+ingress:
+  trustedProxyCIDRs: "10.0.0.0/8,172.16.0.0/12"
+```
+
+Only set this to CIDRs for proxies or load balancers you actually control. Wachd only trusts `X-Forwarded-For` when the immediate peer is in this list.
+
+Your ingress should also overwrite or normalize `X-Forwarded-For` rather than append attacker-controlled values. For nginx-ingress, check settings such as:
+
+```yaml
+use-forwarded-headers: "false"
+compute-full-forwarded-for: "false"
+```
+
+**Behavior change:** after the trusted-proxy hardening, existing deployments behind an ingress with the default empty value will rate-limit per ingress/proxy IP rather than per original client IP until `TRUSTED_PROXY_CIDRS` or `ingress.trustedProxyCIDRs` is configured.
+
 > **Note — TLS certificate on first install:** cert-manager issues the internal mTLS certificate after the chart is deployed. Pods will be `Running` within about 30 seconds, but if you see `CrashLoopBackOff` or failed readiness probes in the first 1–2 minutes, wait for the certificate to be issued:
 > ```bash
 > kubectl get certificate -n wachd   # STATUS should reach True
@@ -372,6 +409,7 @@ A team admin can complete their full configuration in under 5 minutes without in
 See [`helm/wachd/values.yaml`](helm/wachd/values.yaml) for all available options.
 
 The chart includes:
+
 - Horizontal Pod Autoscaler (server: 2–10 replicas, worker: 1–5 replicas)
 - PodDisruptionBudget for zero-downtime upgrades
 - Pod anti-affinity across nodes and zones


### PR DESCRIPTION
## Summary

Follow-up to #30 for #18.

This documents the new trusted proxy CIDR behavior for webhook client IP extraction.

## What changed

- Added `TRUSTED_PROXY_CIDRS` to the README environment variable list.
- Added `TRUSTED_PROXY_CIDRS` to `.env.example`.
- Documented Helm configuration via the existing:

```yaml
ingress:
  trustedProxyCIDRs: ""
```

Added a behavior-change note to CHANGELOG.md.

## Why

#30 changed webhook client IP extraction so X-Forwarded-For is trusted only from configured trusted proxy CIDRs.

That is safer, but it changes behavior for existing deployments behind ingress:

with the default empty value, Wachd ignores X-Forwarded-For
webhook rate limiting uses the ingress/proxy IP
operators must configure TRUSTED_PROXY_CIDRS / ingress.trustedProxyCIDRs to restore per-client-IP rate limiting safely

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / dependency update

## Testing

```
grep -n "TRUSTED_PROXY_CIDRS" README.md .env.example CHANGELOG.md
grep -n "trustedProxyCIDRs" README.md helm/wachd/values.yaml
helm template wachd ./helm/wachd \
  --set ingress.trustedProxyCIDRs=10.0.0.0/8,172.16.0.0/12 \
  | grep TRUSTED_PROXY_CIDRS

helm template wachd ./helm/wachd | grep TRUSTED_PROXY_CIDRS
```

- [ ] Unit tests pass (`make test`)
- [ ] Build passes (`go build ./...`)
- [ ] Static analysis passes (`go vet ./...`)
- [ ] Tested manually against a running instance

## Code Review Checklist

- [ ] All database queries that access team data use `WHERE team_id = $N`
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Error handling returns errors — no panics in production paths
- [ ] New API endpoints validate input (UUIDs, required fields)
- [ ] PII sanitizer is called before any analysis backend call
- [ ] Logs include context (incident ID, team ID) where relevant

## Related Issues

<!-- Closes #<issue number> -->
