### PR TITLE
fix: add /auth/local/login to middleware public paths

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const PUBLIC_PATHS = ['/login', '/auth/login', '/auth/callback']
+const PUBLIC_PATHS = ['/login', '/auth/login', '/auth/local/login', '/auth/callback']
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl


### PR DESCRIPTION
## What

Adds `/auth/local/login` to `PUBLIC_PATHS` in `web/proxy.ts`.

## Why

Local login was broken in `make dev`. The Next.js middleware checks all routes not in `PUBLIC_PATHS` for a session cookie. `/auth/local/login` was missing from the list, so unauthenticated login POSTs were redirected `307 → /login`. The browser followed the redirect, got back the HTML login page, and the JSON client blew up:

```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

## Reproduction (before fix)

```bash
# Start Next.js only (no Go backend needed)
make web

curl -v -X POST http://localhost:3000/auth/local/login \
  -H "Content-Type: application/json" \
  -d '{"username":"test","password":"test"}'
# Returns: HTTP/1.1 307 Temporary Redirect → /login
```

After fix: `500` (backend unreachable) — middleware no longer intercepts.

## Notes

- Only affects local `make dev`. In production k8s, ingress routes `/auth/*` directly to the Go backend, bypassing Next.js middleware entirely.
- Reported by @High-Speed-Diesel in the community.

Closes #32