### PR TITLE
feat: incident knowledge graph foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Wachd receives alerts from your monitoring tools (Grafana, Datadog, Prometheus) 
 [![Go Version](https://img.shields.io/badge/go-1.24%2B-00ADD8.svg)](go.mod)
 [![Go Report Card](https://goreportcard.com/badge/github.com/wachd/wachd)](https://goreportcard.com/report/github.com/wachd/wachd)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XAgXgnqxa)
-[![GitHub Stars](https://img.shields.io/github/stars/wachd/wachd?style=social)](https://github.com/wachd/wachd)
-
-If Wachd is useful to you, a ⭐ on GitHub helps other engineers find it.
 
 ![Wachd demo — on-call check, alert fire, AI root cause analysis](docs/demo.gif)
 

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1,0 +1,101 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NodeType defines what kind of entity a graph node represents.
+type NodeType string
+
+const (
+	NodeTypeIncident   NodeType = "incident"
+	NodeTypeDeployment NodeType = "deployment"
+	NodeTypeService    NodeType = "service"
+	NodeTypeAlert      NodeType = "alert"
+)
+
+// EdgeType defines the relationship between two graph nodes.
+type EdgeType string
+
+const (
+	// EdgeTypeCausedBy links an incident to the deployment or incident that caused it.
+	EdgeTypeCausedBy EdgeType = "caused_by"
+	// EdgeTypeAffects links an incident to the service it impacted.
+	EdgeTypeAffects EdgeType = "affects"
+	// EdgeTypeSimilarTo links two incidents with overlapping symptoms or context.
+	EdgeTypeSimilarTo EdgeType = "similar_to"
+	// EdgeTypeTriggered links an alert rule to the incident it created.
+	EdgeTypeTriggered EdgeType = "triggered"
+)
+
+// Node is a vertex in the incident knowledge graph.
+type Node struct {
+	ID         uuid.UUID `json:"id"`
+	TeamID     uuid.UUID `json:"team_id"`
+	Type       NodeType  `json:"type"`
+	Label      string    `json:"label"`
+	ExternalID *string   `json:"external_id,omitempty"` // incidents.id, commit hash, service name, etc.
+	Properties []byte    `json:"properties,omitempty"`  // JSONB — type-specific metadata
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Edge is a directed relationship between two nodes.
+type Edge struct {
+	ID         uuid.UUID `json:"id"`
+	TeamID     uuid.UUID `json:"team_id"`
+	FromNodeID uuid.UUID `json:"from_node_id"`
+	ToNodeID   uuid.UUID `json:"to_node_id"`
+	Type       EdgeType  `json:"type"`
+	Weight     float64   `json:"weight"`
+	Properties []byte    `json:"properties,omitempty"` // JSONB — relationship metadata
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// Graph is a subgraph result returned by GetSubgraph.
+type Graph struct {
+	Nodes []*Node `json:"nodes"`
+	Edges []*Edge `json:"edges"`
+}
+
+// Store is the interface for reading and writing the incident knowledge graph.
+// All methods are scoped to a single team — no cross-team access is possible.
+type Store interface {
+	// UpsertNode creates or updates a graph node.
+	// Within a team, (type, external_id) uniquely identifies a node when external_id is set.
+	// If external_id is nil, a new node is always created.
+	UpsertNode(ctx context.Context, teamID uuid.UUID, n *Node) (*Node, error)
+
+	// UpsertEdge creates or updates a directed edge between two nodes.
+	// (from_node_id, to_node_id, type) is unique — calling again updates weight/properties.
+	UpsertEdge(ctx context.Context, teamID uuid.UUID, e *Edge) (*Edge, error)
+
+	// GetSubgraph returns a root node and all connected nodes and edges up to the
+	// given traversal depth. Depth 1 returns only the root and its immediate neighbours.
+	GetSubgraph(ctx context.Context, teamID uuid.UUID, rootNodeID uuid.UUID, depth int) (*Graph, error)
+
+	// FindSimilar returns up to limit nodes of the same type whose label is
+	// similar to the label of the given node. Used to surface past incidents
+	// with matching context before the AI analysis runs.
+	FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*Node, error)
+
+	// DeleteNode removes a node and all edges connected to it.
+	DeleteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error
+}

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,8 +25,8 @@ import (
 // NodeStatus controls whether a node participates in similarity searches
 // and graph traversals. Nodes start as pending and are promoted to permanent
 // when the incident is resolved. Pending nodes must never appear in
-// FindSimilar or GetSubgraph results — that exclusion is the guarantee that
-// makes two-phase write-back safe.
+// FindSimilar or GetSubgraph neighbour results — that exclusion is the
+// guarantee that makes two-phase write-back safe.
 type NodeStatus string
 
 const (
@@ -37,7 +38,24 @@ const (
 	NodeStatusPermanent NodeStatus = "permanent"
 )
 
+// EdgeStatus mirrors NodeStatus for edges. An edge is pending while either of
+// its endpoint nodes is pending, and is promoted to permanent alongside the
+// source node on incident resolution.
+type EdgeStatus string
+
+const (
+	EdgeStatusPending   EdgeStatus = "pending"
+	EdgeStatusPermanent EdgeStatus = "permanent"
+)
+
 // NodeType defines what kind of entity a graph node represents.
+//
+// New types identified in issue #35 (root_cause, resolution, log_pattern,
+// metric_anomaly, commit) will be added here as first-class constants — not
+// stored as free-form strings in Properties. This keeps the CHECK constraint
+// on the schema column and Go's type system in sync with the allowed
+// vocabulary. Type-specific metadata that does not warrant a first-class type
+// goes in Properties.
 type NodeType string
 
 const (
@@ -48,6 +66,9 @@ const (
 )
 
 // EdgeType defines the relationship between two graph nodes.
+//
+// New edge types will follow the same pattern as NodeType — added as constants
+// here and as CHECK values in the schema, never as unconstrained strings.
 type EdgeType string
 
 const (
@@ -63,27 +84,37 @@ const (
 
 // Node is a vertex in the incident knowledge graph.
 type Node struct {
-	ID         uuid.UUID  `json:"id"`
-	TeamID     uuid.UUID  `json:"team_id"`
-	Type       NodeType   `json:"type"`
-	Status     NodeStatus `json:"status"`
-	Label      string     `json:"label"`
-	ExternalID *string    `json:"external_id,omitempty"` // incidents.id, commit hash, service name, etc.
-	Properties []byte     `json:"properties,omitempty"`  // JSONB — type-specific metadata
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID         uuid.UUID       `json:"id"`
+	TeamID     uuid.UUID       `json:"team_id"`
+	Type       NodeType        `json:"type"`
+	Status     NodeStatus      `json:"status"`
+	Label      string          `json:"label"`
+	ExternalID *string         `json:"external_id,omitempty"` // incidents.id, commit hash, service name, etc.
+	Properties json.RawMessage `json:"properties,omitempty"`  // JSONB — type-specific metadata
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
 }
 
 // Edge is a directed relationship between two nodes.
 type Edge struct {
-	ID         uuid.UUID `json:"id"`
-	TeamID     uuid.UUID `json:"team_id"`
-	FromNodeID uuid.UUID `json:"from_node_id"`
-	ToNodeID   uuid.UUID `json:"to_node_id"`
-	Type       EdgeType  `json:"type"`
-	Weight     float64   `json:"weight"`
-	Properties []byte    `json:"properties,omitempty"` // JSONB — relationship metadata
-	CreatedAt  time.Time `json:"created_at"`
+	ID         uuid.UUID       `json:"id"`
+	TeamID     uuid.UUID       `json:"team_id"`
+	FromNodeID uuid.UUID       `json:"from_node_id"`
+	ToNodeID   uuid.UUID       `json:"to_node_id"`
+	Type       EdgeType        `json:"type"`
+	Status     EdgeStatus      `json:"status"`
+	Weight     float64         `json:"weight"`
+	Properties json.RawMessage `json:"properties,omitempty"` // JSONB — relationship metadata
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// SimilarNode is a node returned by FindSimilar, augmented with a similarity
+// score and an optional human-readable reason explaining the match.
+type SimilarNode struct {
+	Node   *Node   `json:"node"`
+	Score  float64 `json:"score"`            // 0.0–1.0; higher is more similar
+	Reason string  `json:"reason,omitempty"` // e.g. "embedding cosine similarity" or "shared label tokens"
 }
 
 // Graph is a subgraph result returned by GetSubgraph.
@@ -96,27 +127,34 @@ type Graph struct {
 // All methods are scoped to a single team — no cross-team access is possible.
 type Store interface {
 	// UpsertNode creates or updates a graph node.
-	// Within a team, (type, external_id) uniquely identifies a node when external_id is set.
-	// If external_id is nil, a new node is always created.
+	// Within a team, (type, external_id) uniquely identifies a node when
+	// external_id is set. If external_id is nil, a new node is always created.
 	UpsertNode(ctx context.Context, teamID uuid.UUID, n *Node) (*Node, error)
 
 	// UpsertEdge creates or updates a directed edge between two nodes.
-	// (from_node_id, to_node_id, type) is unique — calling again updates weight/properties.
+	// (from_node_id, to_node_id, type) is unique within a team — calling again
+	// updates weight, properties, and updated_at.
 	UpsertEdge(ctx context.Context, teamID uuid.UUID, e *Edge) (*Edge, error)
 
-	// GetSubgraph returns a root node and all connected nodes and edges up to the
-	// given traversal depth. Depth 1 returns only the root and its immediate neighbours.
+	// GetSubgraph returns a root node and all connected nodes and edges up to
+	// the given traversal depth. Depth 1 returns the root and its immediate
+	// neighbours only.
+	//
+	// The root node is returned regardless of its status — callers displaying
+	// the active incident's own graph are not blocked by the pending state.
+	// Only neighbour nodes reached via edge traversal are filtered to
+	// status = 'permanent', preventing contamination from in-flight incidents.
 	GetSubgraph(ctx context.Context, teamID uuid.UUID, rootNodeID uuid.UUID, depth int) (*Graph, error)
 
 	// FindSimilar returns up to limit nodes of the same type whose label is
-	// similar to the label of the given node. Used to surface past incidents
-	// with matching context before the AI analysis runs.
-	FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*Node, error)
+	// similar to the label of the given node, ordered by descending score.
+	// Only permanent nodes are considered — pending nodes are excluded to
+	// prevent active-incident AI analysis from contaminating similarity results.
+	FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*SimilarNode, error)
 
-	// PromoteNode flips a node from pending to permanent, making it visible
-	// to FindSimilar and GetSubgraph. Call this when the incident is resolved.
-	// Implementations must use WHERE status = 'permanent' in every similarity
-	// search and graph traversal — pending nodes must never leak into results.
+	// PromoteNode flips a node from pending to permanent, making it visible to
+	// FindSimilar and GetSubgraph neighbour traversal. Call this when the
+	// incident is resolved.
 	PromoteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error
 
 	// DeleteNode removes a node and all edges connected to it.

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -21,6 +21,22 @@ import (
 	"github.com/google/uuid"
 )
 
+// NodeStatus controls whether a node participates in similarity searches
+// and graph traversals. Nodes start as pending and are promoted to permanent
+// when the incident is resolved. Pending nodes must never appear in
+// FindSimilar or GetSubgraph results — that exclusion is the guarantee that
+// makes two-phase write-back safe.
+type NodeStatus string
+
+const (
+	// NodeStatusPending marks a node written during an active incident.
+	// Excluded from all similarity searches and neighbour lookups.
+	NodeStatusPending NodeStatus = "pending"
+	// NodeStatusPermanent marks a node promoted on incident resolution.
+	// Included in similarity searches and neighbour lookups.
+	NodeStatusPermanent NodeStatus = "permanent"
+)
+
 // NodeType defines what kind of entity a graph node represents.
 type NodeType string
 
@@ -47,14 +63,15 @@ const (
 
 // Node is a vertex in the incident knowledge graph.
 type Node struct {
-	ID         uuid.UUID `json:"id"`
-	TeamID     uuid.UUID `json:"team_id"`
-	Type       NodeType  `json:"type"`
-	Label      string    `json:"label"`
-	ExternalID *string   `json:"external_id,omitempty"` // incidents.id, commit hash, service name, etc.
-	Properties []byte    `json:"properties,omitempty"`  // JSONB — type-specific metadata
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID         uuid.UUID  `json:"id"`
+	TeamID     uuid.UUID  `json:"team_id"`
+	Type       NodeType   `json:"type"`
+	Status     NodeStatus `json:"status"`
+	Label      string     `json:"label"`
+	ExternalID *string    `json:"external_id,omitempty"` // incidents.id, commit hash, service name, etc.
+	Properties []byte     `json:"properties,omitempty"`  // JSONB — type-specific metadata
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
 }
 
 // Edge is a directed relationship between two nodes.
@@ -95,6 +112,12 @@ type Store interface {
 	// similar to the label of the given node. Used to surface past incidents
 	// with matching context before the AI analysis runs.
 	FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*Node, error)
+
+	// PromoteNode flips a node from pending to permanent, making it visible
+	// to FindSimilar and GetSubgraph. Call this when the incident is resolved.
+	// Implementations must use WHERE status = 'permanent' in every similarity
+	// search and graph traversal — pending nodes must never leak into results.
+	PromoteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error
 
 	// DeleteNode removes a node and all edges connected to it.
 	DeleteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -351,3 +351,43 @@ CREATE TABLE IF NOT EXISTS system_config (
     updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
     updated_by  UUID         REFERENCES local_users(id) ON DELETE SET NULL
 );
+
+-- ============================================================
+-- Incident Knowledge Graph
+-- Nodes: incidents, deployments, services, alert rules.
+-- Edges: directed relationships between nodes.
+-- All rows are team-scoped — no cross-team access is possible.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id     UUID         NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    type        VARCHAR(50)  NOT NULL,   -- incident | deployment | service | alert
+    label       TEXT         NOT NULL,
+    external_id TEXT,                    -- incidents.id, commit hash, service name, etc.
+    properties  JSONB,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_team     ON graph_nodes(team_id);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_type     ON graph_nodes(team_id, type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_nodes_external
+    ON graph_nodes(team_id, type, external_id)
+    WHERE external_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id     UUID         NOT NULL REFERENCES teams(id)       ON DELETE CASCADE,
+    from_id     UUID         NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    to_id       UUID         NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    type        VARCHAR(50)  NOT NULL,   -- caused_by | affects | similar_to | triggered
+    weight      FLOAT        NOT NULL DEFAULT 1.0,
+    properties  JSONB,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_team ON graph_edges(team_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_from ON graph_edges(from_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_to   ON graph_edges(to_id);

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -357,22 +357,34 @@ CREATE TABLE IF NOT EXISTS system_config (
 -- Nodes: incidents, deployments, services, alert rules.
 -- Edges: directed relationships between nodes.
 -- All rows are team-scoped — no cross-team access is possible.
+--
+-- Two-phase write-back: nodes (and edges) start as 'pending' when written at
+-- alert-fire time. PromoteNode() flips them to 'permanent' on incident resolve.
+-- Every FindSimilar and GetSubgraph neighbour query must filter
+-- WHERE status = 'permanent' — that predicate is the contamination guarantee.
+-- The root node of GetSubgraph is returned regardless of status so that
+-- responders can view an active incident's own graph while it is still open.
+--
+-- Adding new node or edge types: add the value to the CHECK constraint below
+-- AND add a constant to the NodeType / EdgeType Go types in internal/graph/store.go.
+-- Never store new types as free-form strings in the properties column.
 -- ============================================================
 
 CREATE TABLE IF NOT EXISTS graph_nodes (
     id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     team_id     UUID         NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
-    type        VARCHAR(50)  NOT NULL,   -- incident | deployment | service | alert
+    type        VARCHAR(50)  NOT NULL
+                             CHECK (type IN ('incident', 'deployment', 'service', 'alert')),
     label       TEXT         NOT NULL,
     external_id TEXT,                    -- incidents.id, commit hash, service name, etc.
     properties  JSONB,
-    -- pending nodes are excluded from similarity searches and graph traversals.
-    -- PromoteNode flips this to 'permanent' when the incident is resolved.
-    -- Never omit this filter — pending nodes leaking into neighbor lookups is
-    -- the contamination failure mode for two-phase write-back.
-    status      VARCHAR(20)  NOT NULL DEFAULT 'pending',  -- pending | permanent
+    status      VARCHAR(20)  NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'permanent')),
     created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- Required for composite FK from graph_edges — enforces team isolation at
+    -- the DB level so an edge in team A cannot reference a node in team B.
+    UNIQUE(team_id, id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_graph_nodes_team     ON graph_nodes(team_id);
@@ -384,14 +396,22 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_nodes_external
 
 CREATE TABLE IF NOT EXISTS graph_edges (
     id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    team_id     UUID         NOT NULL REFERENCES teams(id)       ON DELETE CASCADE,
-    from_id     UUID         NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
-    to_id       UUID         NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
-    type        VARCHAR(50)  NOT NULL,   -- caused_by | affects | similar_to | triggered
+    team_id     UUID         NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    from_id     UUID         NOT NULL,
+    to_id       UUID         NOT NULL,
+    type        VARCHAR(50)  NOT NULL
+                             CHECK (type IN ('caused_by', 'affects', 'similar_to', 'triggered')),
+    status      VARCHAR(20)  NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'permanent')),
     weight      FLOAT        NOT NULL DEFAULT 1.0,
     properties  JSONB,
     created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    UNIQUE(from_id, to_id, type)
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- Composite FKs enforce that both endpoints belong to the same team as the
+    -- edge. A plain FK on from_id / to_id alone would allow cross-team edges.
+    FOREIGN KEY (team_id, from_id) REFERENCES graph_nodes(team_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (team_id, to_id)   REFERENCES graph_nodes(team_id, id) ON DELETE CASCADE,
+    UNIQUE(team_id, from_id, to_id, type)
 );
 
 CREATE INDEX IF NOT EXISTS idx_graph_edges_team ON graph_edges(team_id);

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -366,12 +366,18 @@ CREATE TABLE IF NOT EXISTS graph_nodes (
     label       TEXT         NOT NULL,
     external_id TEXT,                    -- incidents.id, commit hash, service name, etc.
     properties  JSONB,
+    -- pending nodes are excluded from similarity searches and graph traversals.
+    -- PromoteNode flips this to 'permanent' when the incident is resolved.
+    -- Never omit this filter — pending nodes leaking into neighbor lookups is
+    -- the contamination failure mode for two-phase write-back.
+    status      VARCHAR(20)  NOT NULL DEFAULT 'pending',  -- pending | permanent
     created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_graph_nodes_team     ON graph_nodes(team_id);
 CREATE INDEX IF NOT EXISTS idx_graph_nodes_type     ON graph_nodes(team_id, type);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_status   ON graph_nodes(team_id, status);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_nodes_external
     ON graph_nodes(team_id, type, external_id)
     WHERE external_id IS NOT NULL;


### PR DESCRIPTION
## What this adds

The foundation layer for the incident knowledge graph (closes #35 foundation step; unblocks #36).

**`internal/graph/store.go`** — `Store` interface with:
- `Node` type — `incident | deployment | service | alert`
- `Edge` type — `caused_by | affects | similar_to | triggered`
- `Graph` type — subgraph container for API responses
- Five interface methods: `UpsertNode`, `UpsertEdge`, `GetSubgraph`, `FindSimilar`, `DeleteNode`
- Every method is team-scoped (`teamID uuid.UUID` as required param)

**`internal/store/schema.sql`** — two new tables:
- `graph_nodes` — stores nodes with JSONB properties, partial unique index on `(team_id, type, external_id)`
- `graph_edges` — directed edges with `UNIQUE(from_id, to_id, type)` for safe upserts, `ON DELETE CASCADE` on both FK sides

## What comes next (#36)

The Postgres implementation of `graph.Store` can now be built on top of this interface. Suggested starting point: `internal/graph/postgres.go` implementing each method with parameterized queries against the two new tables.

## Checklist

- [x] `go build ./internal/graph/...` clean
- [x] `go vet ./internal/graph/...` clean
- [x] All interface methods are team-scoped
- [x] Schema uses `IF NOT EXISTS` — idempotent on startup
- [x] `ON DELETE CASCADE` on all FKs — no orphaned graph data