### PR TITLE
feat(graph): add smarter incident similarity matching

### DIFF
--- a/internal/graph/postgres_store.go
+++ b/internal/graph/postgres_store.go
@@ -26,10 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const (
-	defaultSimilarityCandidateLimit = 200
-	defaultMinimumSimilarityScore   = 0.12
-)
+const defaultMinimumSimilarityScore = 0.12
 
 // ErrNodeNotFound is returned when a graph operation cannot find the requested
 // node inside the requested team boundary.
@@ -40,8 +37,8 @@ var ErrNodeNotFound = errors.New("graph node not found")
 // It stores graph nodes and edges in the adjacency tables created by
 // internal/store/schema.sql. All operations are scoped by team_id.
 type PostgresStore struct {
-	pool               *pgxpool.Pool
-	candidateLimit     int
+	pool *pgxpool.Pool
+
 	minSimilarityScore float64
 }
 
@@ -51,7 +48,6 @@ var _ Store = (*PostgresStore)(nil)
 func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
 	return &PostgresStore{
 		pool:               pool,
-		candidateLimit:     defaultSimilarityCandidateLimit,
 		minSimilarityScore: defaultMinimumSimilarityScore,
 	}
 }
@@ -349,11 +345,10 @@ func (s *PostgresStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeI
 		return nil, err
 	}
 
-	candidateLimit := s.candidateLimit
-	if expandedLimit := limit * 10; expandedLimit > candidateLimit {
-		candidateLimit = expandedLimit
-	}
-
+	// Score every permanent same-team candidate instead of applying a recency
+	// cutoff. This keeps older but highly similar incidents discoverable. A
+	// future embeddings/pgvector implementation can replace this with indexed
+	// nearest-neighbour retrieval without changing the FindSimilar API.
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
 		FROM graph_nodes
@@ -361,9 +356,7 @@ func (s *PostgresStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeI
 		  AND type = $2
 		  AND status = 'permanent'
 		  AND id <> $3
-		ORDER BY updated_at DESC
-		LIMIT $4
-	`, teamID, source.Type, source.ID, candidateLimit)
+	`, teamID, source.Type, source.ID)
 	if err != nil {
 		return nil, fmt.Errorf("query similar candidates: %w", err)
 	}

--- a/internal/graph/postgres_store.go
+++ b/internal/graph/postgres_store.go
@@ -213,74 +213,93 @@ func (s *PostgresStore) GetSubgraph(ctx context.Context, teamID uuid.UUID, rootN
 
 	nodesByID := map[uuid.UUID]*Node{root.ID: root}
 	edgesByID := map[uuid.UUID]*Edge{}
-	frontier := []uuid.UUID{root.ID}
 
-	for currentDepth := 0; currentDepth < depth && len(frontier) > 0; currentDepth++ {
-		nextFrontier := make([]uuid.UUID, 0)
+	if depth > 0 {
+		rows, err := s.pool.Query(ctx, `
+			WITH RECURSIVE walk(node_id, depth, path, edge_id) AS (
+				SELECT $2::uuid, 0, ARRAY[$2::uuid], NULL::uuid
 
-		for _, nodeID := range frontier {
-			rows, err := s.pool.Query(ctx, `
+				UNION ALL
+
 				SELECT
-					e.id,
-					e.team_id,
-					e.from_id,
-					e.to_id,
-					e.type,
-					e.status,
-					e.weight,
-					e.properties,
-					e.created_at,
-					e.updated_at,
-					n.id,
-					n.team_id,
-					n.type,
-					n.status,
-					n.label,
-					n.external_id,
-					n.properties,
-					n.created_at,
-					n.updated_at
-				FROM graph_edges e
-				JOIN graph_nodes n
-				  ON n.team_id = e.team_id
-				 AND (
-						(e.from_id = $2 AND n.id = e.to_id)
-					 OR (e.to_id = $2 AND n.id = e.from_id)
-				 )
-				WHERE e.team_id = $1
-				  AND e.status = 'permanent'
-				  AND n.status = 'permanent'
-			`, teamID, nodeID)
+					neighbor.id,
+					walk.depth + 1,
+					walk.path || neighbor.id,
+					e.id
+				FROM walk
+				JOIN graph_edges e
+				  ON e.team_id = $1
+				 AND e.status = 'permanent'
+				 AND (e.from_id = walk.node_id OR e.to_id = walk.node_id)
+				JOIN graph_nodes neighbor
+				  ON neighbor.team_id = e.team_id
+				 AND neighbor.id = CASE
+						WHEN e.from_id = walk.node_id THEN e.to_id
+						ELSE e.from_id
+					 END
+				 AND neighbor.status = 'permanent'
+				WHERE walk.depth < $3
+				  AND neighbor.id <> ALL(walk.path)
+			),
+			traversed_edges AS (
+				SELECT DISTINCT edge_id
+				FROM walk
+				WHERE edge_id IS NOT NULL
+			)
+			SELECT
+				e.id,
+				e.team_id,
+				e.from_id,
+				e.to_id,
+				e.type,
+				e.status,
+				e.weight,
+				e.properties,
+				e.created_at,
+				e.updated_at,
+				n.id,
+				n.team_id,
+				n.type,
+				n.status,
+				n.label,
+				n.external_id,
+				n.properties,
+				n.created_at,
+				n.updated_at
+			FROM traversed_edges te
+			JOIN graph_edges e
+			  ON e.id = te.edge_id
+			 AND e.team_id = $1
+			JOIN graph_nodes n
+			  ON n.team_id = e.team_id
+			 AND (n.id = e.from_id OR n.id = e.to_id)
+			WHERE n.id = $2
+			   OR n.status = 'permanent'
+			ORDER BY e.created_at, n.created_at
+		`, teamID, rootNodeID, depth)
+		if err != nil {
+			return nil, fmt.Errorf("get subgraph: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			edge, node, err := scanEdgeAndNode(rows)
 			if err != nil {
-				return nil, fmt.Errorf("get subgraph neighbours: %w", err)
+				return nil, fmt.Errorf("scan subgraph row: %w", err)
 			}
 
-			for rows.Next() {
-				edge, node, err := scanEdgeAndNode(rows)
-				if err != nil {
-					rows.Close()
-					return nil, fmt.Errorf("scan subgraph row: %w", err)
-				}
-
-				if _, exists := edgesByID[edge.ID]; !exists {
-					edgesByID[edge.ID] = edge
-				}
-
-				if _, exists := nodesByID[node.ID]; !exists {
-					nodesByID[node.ID] = node
-					nextFrontier = append(nextFrontier, node.ID)
-				}
+			if _, exists := edgesByID[edge.ID]; !exists {
+				edgesByID[edge.ID] = edge
 			}
 
-			if err := rows.Err(); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("read subgraph rows: %w", err)
+			if _, exists := nodesByID[node.ID]; !exists {
+				nodesByID[node.ID] = node
 			}
-
-			rows.Close()
 		}
 
-		frontier = nextFrontier
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("read subgraph rows: %w", err)
+		}
 	}
 
 	nodes := make([]*Node, 0, len(nodesByID))

--- a/internal/graph/postgres_store.go
+++ b/internal/graph/postgres_store.go
@@ -1,0 +1,591 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultSimilarityCandidateLimit = 200
+	defaultMinimumSimilarityScore   = 0.12
+)
+
+// ErrNodeNotFound is returned when a graph operation cannot find the requested
+// node inside the requested team boundary.
+var ErrNodeNotFound = errors.New("graph node not found")
+
+// PostgresStore is the PostgreSQL implementation of Store.
+//
+// It stores graph nodes and edges in the adjacency tables created by
+// internal/store/schema.sql. All operations are scoped by team_id.
+type PostgresStore struct {
+	pool               *pgxpool.Pool
+	candidateLimit     int
+	minSimilarityScore float64
+}
+
+var _ Store = (*PostgresStore)(nil)
+
+// NewPostgresStore creates a Store backed by PostgreSQL.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{
+		pool:               pool,
+		candidateLimit:     defaultSimilarityCandidateLimit,
+		minSimilarityScore: defaultMinimumSimilarityScore,
+	}
+}
+
+// UpsertNode creates or updates a graph node.
+//
+// If ExternalID is set, the tuple (team_id, type, external_id) is treated as the
+// stable identity for the node. Re-upserting a permanent node never demotes it
+// back to pending.
+func (s *PostgresStore) UpsertNode(ctx context.Context, teamID uuid.UUID, n *Node) (*Node, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if n == nil {
+		return nil, errors.New("graph node is required")
+	}
+	if teamID == uuid.Nil {
+		return nil, errors.New("team id is required")
+	}
+	if n.TeamID != uuid.Nil && n.TeamID != teamID {
+		return nil, fmt.Errorf("node team %s does not match requested team %s", n.TeamID, teamID)
+	}
+	if n.ID == uuid.Nil {
+		n.ID = uuid.New()
+	}
+	if n.Status == "" {
+		n.Status = NodeStatusPending
+	}
+	if strings.TrimSpace(n.Label) == "" {
+		return nil, errors.New("graph node label is required")
+	}
+	if n.ExternalID != nil && strings.TrimSpace(*n.ExternalID) == "" {
+		n.ExternalID = nil
+	}
+
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO graph_nodes (
+			id,
+			team_id,
+			type,
+			status,
+			label,
+			external_id,
+			properties
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (team_id, type, external_id)
+		WHERE external_id IS NOT NULL
+		DO UPDATE SET
+			status = CASE
+				WHEN graph_nodes.status = 'permanent' THEN graph_nodes.status
+				ELSE EXCLUDED.status
+			END,
+			label = EXCLUDED.label,
+			properties = EXCLUDED.properties,
+			updated_at = now()
+		RETURNING id, team_id, type, status, label, external_id, properties, created_at, updated_at
+	`, n.ID, teamID, n.Type, n.Status, n.Label, n.ExternalID, n.Properties)
+
+	created, err := scanNode(row)
+	if err != nil {
+		return nil, fmt.Errorf("upsert graph node: %w", err)
+	}
+
+	return created, nil
+}
+
+// UpsertEdge creates or updates a directed relationship between two nodes.
+//
+// Re-upserting a permanent edge never demotes it back to pending.
+func (s *PostgresStore) UpsertEdge(ctx context.Context, teamID uuid.UUID, e *Edge) (*Edge, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if e == nil {
+		return nil, errors.New("graph edge is required")
+	}
+	if teamID == uuid.Nil {
+		return nil, errors.New("team id is required")
+	}
+	if e.TeamID != uuid.Nil && e.TeamID != teamID {
+		return nil, fmt.Errorf("edge team %s does not match requested team %s", e.TeamID, teamID)
+	}
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	if e.FromNodeID == uuid.Nil {
+		return nil, errors.New("edge from node id is required")
+	}
+	if e.ToNodeID == uuid.Nil {
+		return nil, errors.New("edge to node id is required")
+	}
+	if e.FromNodeID == e.ToNodeID {
+		return nil, errors.New("edge cannot point to the same node")
+	}
+	if e.Status == "" {
+		e.Status = EdgeStatusPending
+	}
+	if e.Weight <= 0 {
+		e.Weight = 1
+	}
+
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO graph_edges (
+			id,
+			team_id,
+			from_id,
+			to_id,
+			type,
+			status,
+			weight,
+			properties
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (team_id, from_id, to_id, type)
+		DO UPDATE SET
+			status = CASE
+				WHEN graph_edges.status = 'permanent' THEN graph_edges.status
+				ELSE EXCLUDED.status
+			END,
+			weight = EXCLUDED.weight,
+			properties = EXCLUDED.properties,
+			updated_at = now()
+		RETURNING id, team_id, from_id, to_id, type, status, weight, properties, created_at, updated_at
+	`, e.ID, teamID, e.FromNodeID, e.ToNodeID, e.Type, e.Status, e.Weight, e.Properties)
+
+	created, err := scanEdge(row)
+	if err != nil {
+		return nil, fmt.Errorf("upsert graph edge: %w", err)
+	}
+
+	return created, nil
+}
+
+// GetSubgraph returns the requested root node plus connected permanent
+// neighbours up to the requested depth.
+//
+// The root node may be pending so the active incident graph can be displayed.
+// Neighbours and edges must be permanent so draft AI data from other active
+// incidents does not leak into traversal results.
+func (s *PostgresStore) GetSubgraph(ctx context.Context, teamID uuid.UUID, rootNodeID uuid.UUID, depth int) (*Graph, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if teamID == uuid.Nil {
+		return nil, errors.New("team id is required")
+	}
+	if rootNodeID == uuid.Nil {
+		return nil, errors.New("root node id is required")
+	}
+	if depth < 0 {
+		depth = 0
+	}
+
+	root, err := s.getNode(ctx, teamID, rootNodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	nodesByID := map[uuid.UUID]*Node{root.ID: root}
+	edgesByID := map[uuid.UUID]*Edge{}
+	frontier := []uuid.UUID{root.ID}
+
+	for currentDepth := 0; currentDepth < depth && len(frontier) > 0; currentDepth++ {
+		nextFrontier := make([]uuid.UUID, 0)
+
+		for _, nodeID := range frontier {
+			rows, err := s.pool.Query(ctx, `
+				SELECT
+					e.id,
+					e.team_id,
+					e.from_id,
+					e.to_id,
+					e.type,
+					e.status,
+					e.weight,
+					e.properties,
+					e.created_at,
+					e.updated_at,
+					n.id,
+					n.team_id,
+					n.type,
+					n.status,
+					n.label,
+					n.external_id,
+					n.properties,
+					n.created_at,
+					n.updated_at
+				FROM graph_edges e
+				JOIN graph_nodes n
+				  ON n.team_id = e.team_id
+				 AND (
+						(e.from_id = $2 AND n.id = e.to_id)
+					 OR (e.to_id = $2 AND n.id = e.from_id)
+				 )
+				WHERE e.team_id = $1
+				  AND e.status = 'permanent'
+				  AND n.status = 'permanent'
+			`, teamID, nodeID)
+			if err != nil {
+				return nil, fmt.Errorf("get subgraph neighbours: %w", err)
+			}
+
+			for rows.Next() {
+				edge, node, err := scanEdgeAndNode(rows)
+				if err != nil {
+					rows.Close()
+					return nil, fmt.Errorf("scan subgraph row: %w", err)
+				}
+
+				if _, exists := edgesByID[edge.ID]; !exists {
+					edgesByID[edge.ID] = edge
+				}
+
+				if _, exists := nodesByID[node.ID]; !exists {
+					nodesByID[node.ID] = node
+					nextFrontier = append(nextFrontier, node.ID)
+				}
+			}
+
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("read subgraph rows: %w", err)
+			}
+
+			rows.Close()
+		}
+
+		frontier = nextFrontier
+	}
+
+	nodes := make([]*Node, 0, len(nodesByID))
+	for _, node := range nodesByID {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].CreatedAt.Before(nodes[j].CreatedAt)
+	})
+
+	edges := make([]*Edge, 0, len(edgesByID))
+	for _, edge := range edgesByID {
+		edges = append(edges, edge)
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		return edges[i].CreatedAt.Before(edges[j].CreatedAt)
+	})
+
+	return &Graph{
+		Nodes: nodes,
+		Edges: edges,
+	}, nil
+}
+
+// FindSimilar compares the requested node against permanent nodes of the same
+// type in the same team.
+//
+// It returns the best matches ordered by descending score. Pending candidates
+// are always excluded to prevent in-flight incident analysis from polluting team
+// memory.
+func (s *PostgresStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*SimilarNode, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if teamID == uuid.Nil {
+		return nil, errors.New("team id is required")
+	}
+	if nodeID == uuid.Nil {
+		return nil, errors.New("node id is required")
+	}
+	if limit <= 0 {
+		return []*SimilarNode{}, nil
+	}
+
+	source, err := s.getNode(ctx, teamID, nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	candidateLimit := s.candidateLimit
+	if expandedLimit := limit * 10; expandedLimit > candidateLimit {
+		candidateLimit = expandedLimit
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
+		FROM graph_nodes
+		WHERE team_id = $1
+		  AND type = $2
+		  AND status = 'permanent'
+		  AND id <> $3
+		ORDER BY updated_at DESC
+		LIMIT $4
+	`, teamID, source.Type, source.ID, candidateLimit)
+	if err != nil {
+		return nil, fmt.Errorf("query similar candidates: %w", err)
+	}
+	defer rows.Close()
+
+	matches := make([]*SimilarNode, 0, limit)
+	for rows.Next() {
+		candidate, err := scanNode(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan similar candidate: %w", err)
+		}
+
+		match := scoreNodeSimilarity(source, candidate)
+		if match.Score < s.minSimilarityScore {
+			continue
+		}
+
+		matches = append(matches, match)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read similar candidates: %w", err)
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].Score == matches[j].Score {
+			return matches[i].Node.CreatedAt.After(matches[j].Node.CreatedAt)
+		}
+
+		return matches[i].Score > matches[j].Score
+	})
+
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+
+	return matches, nil
+}
+
+// PromoteNode marks a node as permanent.
+//
+// Any connected edges are promoted only when both endpoint nodes are permanent.
+func (s *PostgresStore) PromoteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error {
+	if err := s.validate(); err != nil {
+		return err
+	}
+	if teamID == uuid.Nil {
+		return errors.New("team id is required")
+	}
+	if nodeID == uuid.Nil {
+		return errors.New("node id is required")
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("promote node begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE graph_nodes
+		SET status = 'permanent',
+			updated_at = now()
+		WHERE team_id = $1
+		  AND id = $2
+	`, teamID, nodeID)
+	if err != nil {
+		return fmt.Errorf("promote graph node: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNodeNotFound
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE graph_edges e
+		SET status = 'permanent',
+			updated_at = now()
+		WHERE e.team_id = $1
+		  AND (e.from_id = $2 OR e.to_id = $2)
+		  AND EXISTS (
+				SELECT 1
+				FROM graph_nodes from_node
+				WHERE from_node.team_id = e.team_id
+				  AND from_node.id = e.from_id
+				  AND from_node.status = 'permanent'
+		  )
+		  AND EXISTS (
+				SELECT 1
+				FROM graph_nodes to_node
+				WHERE to_node.team_id = e.team_id
+				  AND to_node.id = e.to_id
+				  AND to_node.status = 'permanent'
+		  )
+	`, teamID, nodeID); err != nil {
+		return fmt.Errorf("promote graph edges: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("promote node commit: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteNode removes a node and all connected edges.
+func (s *PostgresStore) DeleteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error {
+	if err := s.validate(); err != nil {
+		return err
+	}
+	if teamID == uuid.Nil {
+		return errors.New("team id is required")
+	}
+	if nodeID == uuid.Nil {
+		return errors.New("node id is required")
+	}
+
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM graph_nodes
+		WHERE team_id = $1
+		  AND id = $2
+	`, teamID, nodeID)
+	if err != nil {
+		return fmt.Errorf("delete graph node: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNodeNotFound
+	}
+
+	return nil
+}
+
+func (s *PostgresStore) validate() error {
+	if s == nil {
+		return errors.New("graph store is nil")
+	}
+	if s.pool == nil {
+		return errors.New("graph store database pool is nil")
+	}
+	return nil
+}
+
+func (s *PostgresStore) getNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) (*Node, error) {
+	node, err := scanNode(s.pool.QueryRow(ctx, `
+		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
+		FROM graph_nodes
+		WHERE team_id = $1
+		  AND id = $2
+	`, teamID, nodeID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNodeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get graph node: %w", err)
+	}
+
+	return node, nil
+}
+
+type nodeRow interface {
+	Scan(dest ...any) error
+}
+
+func scanNode(row nodeRow) (*Node, error) {
+	node := &Node{}
+	var properties []byte
+
+	if err := row.Scan(
+		&node.ID,
+		&node.TeamID,
+		&node.Type,
+		&node.Status,
+		&node.Label,
+		&node.ExternalID,
+		&properties,
+		&node.CreatedAt,
+		&node.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	node.Properties = properties
+
+	return node, nil
+}
+
+func scanEdge(row nodeRow) (*Edge, error) {
+	edge := &Edge{}
+	var properties []byte
+
+	if err := row.Scan(
+		&edge.ID,
+		&edge.TeamID,
+		&edge.FromNodeID,
+		&edge.ToNodeID,
+		&edge.Type,
+		&edge.Status,
+		&edge.Weight,
+		&properties,
+		&edge.CreatedAt,
+		&edge.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	edge.Properties = properties
+
+	return edge, nil
+}
+
+func scanEdgeAndNode(row nodeRow) (*Edge, *Node, error) {
+	edge := &Edge{}
+	node := &Node{}
+	var edgeProperties []byte
+	var nodeProperties []byte
+
+	if err := row.Scan(
+		&edge.ID,
+		&edge.TeamID,
+		&edge.FromNodeID,
+		&edge.ToNodeID,
+		&edge.Type,
+		&edge.Status,
+		&edge.Weight,
+		&edgeProperties,
+		&edge.CreatedAt,
+		&edge.UpdatedAt,
+		&node.ID,
+		&node.TeamID,
+		&node.Type,
+		&node.Status,
+		&node.Label,
+		&node.ExternalID,
+		&nodeProperties,
+		&node.CreatedAt,
+		&node.UpdatedAt,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	edge.Properties = edgeProperties
+	node.Properties = nodeProperties
+
+	return edge, node, nil
+}

--- a/internal/graph/postgres_store_integration_test.go
+++ b/internal/graph/postgres_store_integration_test.go
@@ -144,6 +144,187 @@ func TestPostgresStoreFindSimilar(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreGetSubgraphUsesRecursiveTraversal(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL is required for integration tests")
+	}
+
+	ctx := context.Background()
+
+	db, err := store.NewDB(databaseURL)
+	if err != nil {
+		t.Fatalf("connect database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+
+	team, err := db.CreateTeam(ctx, "graph-subgraph-test-"+uuid.NewString(), "secret-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	defer func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id = $1", team.ID)
+	}()
+
+	graphStore := NewPostgresStore(db.Pool())
+
+	rootExternalID := "root-" + uuid.NewString()
+	root, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPending,
+		Label:      "Active checkout incident",
+		ExternalID: &rootExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service": "checkout-api",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert root: %v", err)
+	}
+
+	serviceExternalID := "service-" + uuid.NewString()
+	service, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeService,
+		Status:     NodeStatusPermanent,
+		Label:      "checkout-api",
+		ExternalID: &serviceExternalID,
+	})
+	if err != nil {
+		t.Fatalf("upsert service: %v", err)
+	}
+
+	deploymentExternalID := "deployment-" + uuid.NewString()
+	deployment, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeDeployment,
+		Status:     NodeStatusPermanent,
+		Label:      "checkout deployment",
+		ExternalID: &deploymentExternalID,
+	})
+	if err != nil {
+		t.Fatalf("upsert deployment: %v", err)
+	}
+
+	pendingExternalID := "pending-" + uuid.NewString()
+	pendingNeighbour, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeService,
+		Status:     NodeStatusPending,
+		Label:      "draft service",
+		ExternalID: &pendingExternalID,
+	})
+	if err != nil {
+		t.Fatalf("upsert pending neighbour: %v", err)
+	}
+
+	rootToService, err := graphStore.UpsertEdge(ctx, team.ID, &Edge{
+		FromNodeID: root.ID,
+		ToNodeID:   service.ID,
+		Type:       EdgeTypeAffects,
+		Status:     EdgeStatusPermanent,
+		Weight:     1,
+	})
+	if err != nil {
+		t.Fatalf("upsert root-to-service edge: %v", err)
+	}
+
+	serviceToDeployment, err := graphStore.UpsertEdge(ctx, team.ID, &Edge{
+		FromNodeID: service.ID,
+		ToNodeID:   deployment.ID,
+		Type:       EdgeTypeCausedBy,
+		Status:     EdgeStatusPermanent,
+		Weight:     1,
+	})
+	if err != nil {
+		t.Fatalf("upsert service-to-deployment edge: %v", err)
+	}
+
+	rootToPending, err := graphStore.UpsertEdge(ctx, team.ID, &Edge{
+		FromNodeID: root.ID,
+		ToNodeID:   pendingNeighbour.ID,
+		Type:       EdgeTypeAffects,
+		Status:     EdgeStatusPermanent,
+		Weight:     1,
+	})
+	if err != nil {
+		t.Fatalf("upsert root-to-pending edge: %v", err)
+	}
+
+	depthOne, err := graphStore.GetSubgraph(ctx, team.ID, root.ID, 1)
+	if err != nil {
+		t.Fatalf("get depth-one subgraph: %v", err)
+	}
+
+	requireGraphHasNode(t, depthOne, root.ID)
+	requireGraphHasNode(t, depthOne, service.ID)
+	requireGraphDoesNotHaveNode(t, depthOne, deployment.ID)
+	requireGraphDoesNotHaveNode(t, depthOne, pendingNeighbour.ID)
+
+	requireGraphHasEdge(t, depthOne, rootToService.ID)
+	requireGraphDoesNotHaveEdge(t, depthOne, serviceToDeployment.ID)
+	requireGraphDoesNotHaveEdge(t, depthOne, rootToPending.ID)
+
+	depthTwo, err := graphStore.GetSubgraph(ctx, team.ID, root.ID, 2)
+	if err != nil {
+		t.Fatalf("get depth-two subgraph: %v", err)
+	}
+
+	requireGraphHasNode(t, depthTwo, root.ID)
+	requireGraphHasNode(t, depthTwo, service.ID)
+	requireGraphHasNode(t, depthTwo, deployment.ID)
+	requireGraphDoesNotHaveNode(t, depthTwo, pendingNeighbour.ID)
+
+	requireGraphHasEdge(t, depthTwo, rootToService.ID)
+	requireGraphHasEdge(t, depthTwo, serviceToDeployment.ID)
+	requireGraphDoesNotHaveEdge(t, depthTwo, rootToPending.ID)
+}
+
+func requireGraphHasNode(t *testing.T, graph *Graph, nodeID uuid.UUID) {
+	t.Helper()
+
+	for _, node := range graph.Nodes {
+		if node.ID == nodeID {
+			return
+		}
+	}
+
+	t.Fatalf("expected graph to contain node %s", nodeID)
+}
+
+func requireGraphDoesNotHaveNode(t *testing.T, graph *Graph, nodeID uuid.UUID) {
+	t.Helper()
+
+	for _, node := range graph.Nodes {
+		if node.ID == nodeID {
+			t.Fatalf("expected graph not to contain node %s", nodeID)
+		}
+	}
+}
+
+func requireGraphHasEdge(t *testing.T, graph *Graph, edgeID uuid.UUID) {
+	t.Helper()
+
+	for _, edge := range graph.Edges {
+		if edge.ID == edgeID {
+			return
+		}
+	}
+
+	t.Fatalf("expected graph to contain edge %s", edgeID)
+}
+
+func requireGraphDoesNotHaveEdge(t *testing.T, graph *Graph, edgeID uuid.UUID) {
+	t.Helper()
+
+	for _, edge := range graph.Edges {
+		if edge.ID == edgeID {
+			t.Fatalf("expected graph not to contain edge %s", edgeID)
+		}
+	}
+}
+
 func rawJSON(t *testing.T, value any) json.RawMessage {
 	t.Helper()
 

--- a/internal/graph/postgres_store_integration_test.go
+++ b/internal/graph/postgres_store_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func TestPostgresStoreFindSimilar(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL is required for integration tests")
+	}
+
+	ctx := context.Background()
+
+	db, err := store.NewDB(databaseURL)
+	if err != nil {
+		t.Fatalf("connect database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+
+	team, err := db.CreateTeam(ctx, "graph-test-"+uuid.NewString(), "secret-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	defer func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id = $1", team.ID)
+	}()
+
+	graphStore := NewPostgresStore(db.Pool())
+
+	sourceExternalID := "source-" + uuid.NewString()
+	source, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPending,
+		Label:      "Checkout 500 errors after deploy",
+		ExternalID: &sourceExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "checkout-api",
+			"root_cause":   "database connection pool exhausted",
+			"log_patterns": []string{"postgres connection refused"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert source: %v", err)
+	}
+
+	similarExternalID := "similar-" + uuid.NewString()
+	similar, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPermanent,
+		Label:      "Checkout database connection failures",
+		ExternalID: &similarExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "checkout-api",
+			"root_cause":   "postgres connection pool exhausted",
+			"log_patterns": []string{"database connection refused"},
+			"resolution":   "increased postgres connection limit",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert similar: %v", err)
+	}
+
+	unrelatedExternalID := "unrelated-" + uuid.NewString()
+	if _, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPermanent,
+		Label:      "Email delivery delayed",
+		ExternalID: &unrelatedExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "email-worker",
+			"root_cause":   "SMTP provider throttling",
+			"log_patterns": []string{"smtp 421 rate limit"},
+		}),
+	}); err != nil {
+		t.Fatalf("upsert unrelated: %v", err)
+	}
+
+	pendingExternalID := "pending-" + uuid.NewString()
+	pending, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPending,
+		Label:      "Checkout database connection refused",
+		ExternalID: &pendingExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "checkout-api",
+			"root_cause":   "postgres connection pool exhausted",
+			"log_patterns": []string{"database connection refused"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert pending: %v", err)
+	}
+
+	matches, err := graphStore.FindSimilar(ctx, team.ID, source.ID, 2)
+	if err != nil {
+		t.Fatalf("find similar: %v", err)
+	}
+
+	if len(matches) == 0 {
+		t.Fatal("expected at least one similar incident")
+	}
+
+	if matches[0].Node.ID != similar.ID {
+		t.Fatalf("expected best match %s, got %s", similar.ID, matches[0].Node.ID)
+	}
+
+	for _, match := range matches {
+		if match.Node.ID == pending.ID {
+			t.Fatalf("pending node leaked into FindSimilar results: %s", pending.ID)
+		}
+		if match.Score <= 0 {
+			t.Fatalf("expected positive score for match %s", match.Node.ID)
+		}
+		if match.Reason == "" {
+			t.Fatalf("expected reason for match %s", match.Node.ID)
+		}
+	}
+}
+
+func rawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+
+	return encoded
+}

--- a/internal/graph/postgres_store_integration_test.go
+++ b/internal/graph/postgres_store_integration_test.go
@@ -325,6 +325,116 @@ func requireGraphDoesNotHaveEdge(t *testing.T, graph *Graph, edgeID uuid.UUID) {
 	}
 }
 
+func TestPostgresStoreFindSimilarIncludesOlderIncidents(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL is required for integration tests")
+	}
+
+	ctx := context.Background()
+
+	db, err := store.NewDB(databaseURL)
+	if err != nil {
+		t.Fatalf("connect database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+
+	team, err := db.CreateTeam(ctx, "graph-old-similar-test-"+uuid.NewString(), "secret-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	defer func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id = $1", team.ID)
+	}()
+
+	graphStore := NewPostgresStore(db.Pool())
+
+	oldSimilarExternalID := "old-similar-" + uuid.NewString()
+	oldSimilar, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPermanent,
+		Label:      "Checkout database connection pool exhausted",
+		ExternalID: &oldSimilarExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "checkout-api",
+			"root_cause":   "postgres connection pool exhausted",
+			"log_patterns": []string{"database connection refused", "timeout waiting for postgres connection"},
+			"resolution":   "increased postgres connection pool size",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert old similar incident: %v", err)
+	}
+
+	_, err = db.Pool().Exec(ctx, `
+		UPDATE graph_nodes
+		SET updated_at = now() - interval '30 days'
+		WHERE id = $1
+	`, oldSimilar.ID)
+	if err != nil {
+		t.Fatalf("make old similar incident older: %v", err)
+	}
+
+	for i := 0; i < 205; i++ {
+		unrelatedExternalID := "unrelated-" + uuid.NewString()
+		if _, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+			Type:       NodeTypeIncident,
+			Status:     NodeStatusPermanent,
+			Label:      "Email delivery delayed",
+			ExternalID: &unrelatedExternalID,
+			Properties: rawJSON(t, map[string]any{
+				"service":      "email-worker",
+				"root_cause":   "third party SMTP provider throttling",
+				"log_patterns": []string{"smtp 421 rate limited"},
+				"resolution":   "queued retries and waited for provider limit reset",
+			}),
+		}); err != nil {
+			t.Fatalf("upsert unrelated incident %d: %v", i, err)
+		}
+	}
+
+	sourceExternalID := "source-" + uuid.NewString()
+	source, err := graphStore.UpsertNode(ctx, team.ID, &Node{
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPending,
+		Label:      "Checkout 500 errors after deploy",
+		ExternalID: &sourceExternalID,
+		Properties: rawJSON(t, map[string]any{
+			"service":      "checkout-api",
+			"root_cause":   "database connection pool exhausted",
+			"log_patterns": []string{"postgres connection refused", "timeout acquiring database connection"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("upsert source incident: %v", err)
+	}
+
+	matches, err := graphStore.FindSimilar(ctx, team.ID, source.ID, 1)
+	if err != nil {
+		t.Fatalf("find similar: %v", err)
+	}
+
+	if len(matches) != 1 {
+		t.Fatalf("expected one match, got %d", len(matches))
+	}
+
+	if matches[0].Node.ID != oldSimilar.ID {
+		t.Fatalf("expected old similar incident %s, got %s", oldSimilar.ID, matches[0].Node.ID)
+	}
+
+	if matches[0].Score <= 0 {
+		t.Fatalf("expected positive similarity score, got %.3f", matches[0].Score)
+	}
+
+	if matches[0].Reason == "" {
+		t.Fatal("expected similarity reason")
+	}
+}
+
 func rawJSON(t *testing.T, value any) json.RawMessage {
 	t.Helper()
 

--- a/internal/graph/similarity.go
+++ b/internal/graph/similarity.go
@@ -1,0 +1,425 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+const maxSimilarityReasons = 3
+
+type similaritySignal struct {
+	name       string
+	reason     string
+	weight     float64
+	source     string
+	candidate  string
+	exactMatch bool
+}
+
+// scoreNodeSimilarity compares two graph nodes and returns the candidate wrapped
+// in SimilarNode with a normalized 0.0-1.0 score.
+//
+// The scorer is intentionally metadata-aware instead of doing a plain keyword
+// search. It gives separate weights to the signals called out in issue #36:
+// root cause, log patterns, affected service, metric anomalies, deploys/commits,
+// previous resolution, and the incident title/label.
+//
+// This is also the seam where a future pgvector embedding score can be blended
+// in without changing the public FindSimilar API.
+func scoreNodeSimilarity(source, candidate *Node) *SimilarNode {
+	if candidate == nil {
+		return &SimilarNode{Score: 0, Reason: "no candidate node"}
+	}
+	if source == nil {
+		return &SimilarNode{Node: candidate, Score: 0, Reason: "no source node"}
+	}
+
+	sourceProps := parseProperties(source.Properties)
+	candidateProps := parseProperties(candidate.Properties)
+
+	signals := []similaritySignal{
+		{
+			name:      "title",
+			reason:    "similar alert title",
+			weight:    0.20,
+			source:    source.Label,
+			candidate: candidate.Label,
+		},
+		{
+			name:      "root cause",
+			reason:    "similar root cause text",
+			weight:    0.25,
+			source:    propertyText(sourceProps, "root_cause", "rootCause", "cause", "probable_cause"),
+			candidate: propertyText(candidateProps, "root_cause", "rootCause", "cause", "probable_cause"),
+		},
+		{
+			name:      "log pattern",
+			reason:    "similar log pattern",
+			weight:    0.20,
+			source:    propertyText(sourceProps, "log_pattern", "log_patterns", "logs", "error_logs", "errorLogs"),
+			candidate: propertyText(candidateProps, "log_pattern", "log_patterns", "logs", "error_logs", "errorLogs"),
+		},
+		{
+			name:       "affected service",
+			reason:     "same affected service",
+			weight:     0.15,
+			source:     propertyText(sourceProps, "service", "affected_service", "affectedService", "service_name", "serviceName"),
+			candidate:  propertyText(candidateProps, "service", "affected_service", "affectedService", "service_name", "serviceName"),
+			exactMatch: true,
+		},
+		{
+			name:      "metric anomaly",
+			reason:    "similar metric anomaly",
+			weight:    0.10,
+			source:    propertyText(sourceProps, "metric_anomaly", "metric_anomalies", "metrics", "metrics_summary", "metricsSummary"),
+			candidate: propertyText(candidateProps, "metric_anomaly", "metric_anomalies", "metrics", "metrics_summary", "metricsSummary"),
+		},
+		{
+			name:      "deployment",
+			reason:    "similar deployment or commit context",
+			weight:    0.05,
+			source:    propertyText(sourceProps, "deployment", "deploy", "commit", "commits", "recent_commits", "recentCommits", "sha"),
+			candidate: propertyText(candidateProps, "deployment", "deploy", "commit", "commits", "recent_commits", "recentCommits", "sha"),
+		},
+		{
+			name:      "resolution",
+			reason:    "similar previous resolution",
+			weight:    0.05,
+			source:    propertyText(sourceProps, "resolution", "resolved_by", "resolvedBy", "fix", "suggested_action", "suggestedAction"),
+			candidate: propertyText(candidateProps, "resolution", "resolved_by", "resolvedBy", "fix", "suggested_action", "suggestedAction"),
+		},
+	}
+
+	var weightedScore float64
+	var availableWeight float64
+	reasons := make([]string, 0, maxSimilarityReasons)
+
+	for _, signal := range signals {
+		if strings.TrimSpace(signal.source) == "" {
+			continue
+		}
+
+		availableWeight += signal.weight
+
+		score := fieldSimilarity(signal.source, signal.candidate, signal.exactMatch)
+		weightedScore += signal.weight * score
+
+		if score >= 0.65 && len(reasons) < maxSimilarityReasons {
+			reason := signal.reason
+			if signal.exactMatch {
+				reason = fmt.Sprintf("%s: %s", signal.reason, shortText(signal.candidate, 80))
+			}
+			reasons = append(reasons, reason)
+		}
+	}
+
+	if availableWeight == 0 {
+		return &SimilarNode{
+			Node:   candidate,
+			Score:  0,
+			Reason: "no comparable incident fields",
+		}
+	}
+
+	score := clamp(weightedScore/availableWeight, 0, 1)
+	reason := strings.Join(reasons, "; ")
+	if reason == "" {
+		if score > 0 {
+			reason = "similar incident context"
+		} else {
+			reason = "no strong similarity signals"
+		}
+	}
+
+	return &SimilarNode{
+		Node:   candidate,
+		Score:  roundScore(score),
+		Reason: reason,
+	}
+}
+
+func parseProperties(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "null" {
+		return map[string]any{}
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(raw, &props); err != nil {
+		return map[string]any{}
+	}
+
+	return props
+}
+
+func propertyText(props map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := findProperty(props, normalizeKey(key))
+		if !ok {
+			continue
+		}
+
+		text := strings.TrimSpace(flattenValue(value))
+		if text != "" {
+			return text
+		}
+	}
+
+	return ""
+}
+
+func findProperty(value any, normalizedKey string) (any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if normalizeKey(key) == normalizedKey {
+				return child, true
+			}
+		}
+
+		for _, child := range typed {
+			if found, ok := findProperty(child, normalizedKey); ok {
+				return found, true
+			}
+		}
+
+	case []any:
+		for _, child := range typed {
+			if found, ok := findProperty(child, normalizedKey); ok {
+				return found, true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func flattenValue(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case float64, float32, int, int64, int32, bool:
+		return fmt.Sprint(typed)
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := strings.TrimSpace(flattenValue(item)); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	case map[string]any:
+		preferredKeys := []string{
+			"message",
+			"name",
+			"label",
+			"summary",
+			"value",
+			"metric",
+			"service",
+			"root_cause",
+			"rootCause",
+			"resolution",
+			"sha",
+		}
+
+		parts := make([]string, 0, len(typed))
+		for _, key := range preferredKeys {
+			if value, ok := typed[key]; ok {
+				if text := strings.TrimSpace(flattenValue(value)); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+
+		if len(parts) > 0 {
+			return strings.Join(parts, " ")
+		}
+
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			if text := strings.TrimSpace(flattenValue(typed[key])); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func fieldSimilarity(source, candidate string, exactMatch bool) float64 {
+	source = strings.TrimSpace(source)
+	candidate = strings.TrimSpace(candidate)
+
+	if source == "" || candidate == "" {
+		return 0
+	}
+
+	if exactMatch {
+		sourceNorm := normalizePhrase(source)
+		candidateNorm := normalizePhrase(candidate)
+
+		if sourceNorm == candidateNorm {
+			return 1
+		}
+
+		if sourceNorm != "" && candidateNorm != "" &&
+			(strings.Contains(sourceNorm, candidateNorm) || strings.Contains(candidateNorm, sourceNorm)) {
+			return 0.75
+		}
+	}
+
+	return tokenSimilarity(source, candidate)
+}
+
+func tokenSimilarity(left, right string) float64 {
+	leftTokens := tokenSet(left)
+	rightTokens := tokenSet(right)
+
+	if len(leftTokens) == 0 || len(rightTokens) == 0 {
+		return 0
+	}
+
+	intersection := 0
+	for token := range leftTokens {
+		if _, ok := rightTokens[token]; ok {
+			intersection++
+		}
+	}
+
+	if intersection == 0 {
+		return 0
+	}
+
+	return float64(2*intersection) / float64(len(leftTokens)+len(rightTokens))
+}
+
+func tokenSet(text string) map[string]struct{} {
+	fields := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+
+	tokens := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		token := strings.TrimSpace(field)
+		if token == "" {
+			continue
+		}
+
+		if _, stop := stopWords[token]; stop {
+			continue
+		}
+
+		tokens[token] = struct{}{}
+	}
+
+	return tokens
+}
+
+func normalizePhrase(text string) string {
+	tokens := tokenSet(text)
+	if len(tokens) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(tokens))
+	for token := range tokens {
+		parts = append(parts, token)
+	}
+	sort.Strings(parts)
+
+	return strings.Join(parts, " ")
+}
+
+func normalizeKey(key string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(key) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func shortText(text string, maxLen int) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= maxLen {
+		return text
+	}
+
+	if maxLen <= 1 {
+		return text[:maxLen]
+	}
+
+	return text[:maxLen-1] + "…"
+}
+
+func clamp(value, minValue, maxValue float64) float64 {
+	return math.Max(minValue, math.Min(maxValue, value))
+}
+
+func roundScore(value float64) float64 {
+	return math.Round(value*1000) / 1000
+}
+
+var stopWords = map[string]struct{}{
+	"a":       {},
+	"an":      {},
+	"and":     {},
+	"are":     {},
+	"as":      {},
+	"at":      {},
+	"be":      {},
+	"by":      {},
+	"for":     {},
+	"from":    {},
+	"has":     {},
+	"have":    {},
+	"in":      {},
+	"is":      {},
+	"it":      {},
+	"of":      {},
+	"on":      {},
+	"or":      {},
+	"that":    {},
+	"the":     {},
+	"this":    {},
+	"to":      {},
+	"was":     {},
+	"were":    {},
+	"with":    {},
+	"after":   {},
+	"before":  {},
+	"during":  {},
+	"service": {},
+	"alert":   {},
+	"error":   {},
+	"errors":  {},
+	"failure": {},
+	"failed":  {},
+}

--- a/internal/graph/similarity_test.go
+++ b/internal/graph/similarity_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestScoreNodeSimilarityUsesIssue36Signals(t *testing.T) {
+	source := testIncidentNode(t, "Checkout 500 errors after deploy", map[string]any{
+		"service":        "checkout-api",
+		"root_cause":     "database connection pool exhausted",
+		"log_patterns":   []string{"connection refused from postgres", "timeout acquiring database connection"},
+		"metric_anomaly": "5xx rate increased above threshold",
+		"commit":         "abc123 changed checkout connection pooling",
+	})
+
+	similar := testIncidentNode(t, "Checkout API database connection failures", map[string]any{
+		"service":      "checkout-api",
+		"root_cause":   "postgres connection pool exhausted after deploy",
+		"log_patterns": []string{"database connection refused", "timeout waiting for postgres connection"},
+		"resolution":   "increased postgres max connections and rolled back pooling change",
+	})
+
+	unrelated := testIncidentNode(t, "Email delivery delayed", map[string]any{
+		"service":      "email-worker",
+		"root_cause":   "third-party SMTP provider throttling",
+		"log_patterns": []string{"smtp 421 rate limited"},
+		"resolution":   "queued retries and changed provider limit",
+	})
+
+	similarScore := scoreNodeSimilarity(source, similar)
+	unrelatedScore := scoreNodeSimilarity(source, unrelated)
+
+	if similarScore.Score <= unrelatedScore.Score {
+		t.Fatalf("expected similar incident score %.3f to be higher than unrelated score %.3f", similarScore.Score, unrelatedScore.Score)
+	}
+
+	if similarScore.Score < 0.55 {
+		t.Fatalf("expected strong similarity score, got %.3f (%s)", similarScore.Score, similarScore.Reason)
+	}
+
+	if !strings.Contains(similarScore.Reason, "same affected service") {
+		t.Fatalf("expected affected service in reason, got %q", similarScore.Reason)
+	}
+
+	if !strings.Contains(similarScore.Reason, "similar log pattern") {
+		t.Fatalf("expected log pattern in reason, got %q", similarScore.Reason)
+	}
+}
+
+func TestScoreNodeSimilarityFallsBackToIncidentTitle(t *testing.T) {
+	source := testIncidentNode(t, "High CPU usage on web server", nil)
+	similar := testIncidentNode(t, "CPU usage high on web-server", nil)
+	unrelated := testIncidentNode(t, "Database connection refused", nil)
+
+	similarScore := scoreNodeSimilarity(source, similar)
+	unrelatedScore := scoreNodeSimilarity(source, unrelated)
+
+	if similarScore.Score <= unrelatedScore.Score {
+		t.Fatalf("expected title match %.3f to beat unrelated %.3f", similarScore.Score, unrelatedScore.Score)
+	}
+
+	if similarScore.Score == 0 {
+		t.Fatal("expected non-zero title similarity score")
+	}
+}
+
+func TestScoreNodeSimilarityDoesNotLetServiceAloneDominate(t *testing.T) {
+	source := testIncidentNode(t, "Checkout 500 errors", map[string]any{
+		"service":      "checkout-api",
+		"root_cause":   "database connection pool exhausted",
+		"log_patterns": []string{"postgres connection refused"},
+	})
+
+	weakMatch := testIncidentNode(t, "Checkout cache warmup slow", map[string]any{
+		"service":      "checkout-api",
+		"root_cause":   "large cache refill after deploy",
+		"log_patterns": []string{"redis cache miss"},
+	})
+
+	strongMatch := testIncidentNode(t, "Checkout database connection failures", map[string]any{
+		"service":      "checkout-api",
+		"root_cause":   "postgres connection pool exhausted",
+		"log_patterns": []string{"database connection refused"},
+	})
+
+	weakScore := scoreNodeSimilarity(source, weakMatch)
+	strongScore := scoreNodeSimilarity(source, strongMatch)
+
+	if weakScore.Score >= strongScore.Score {
+		t.Fatalf("expected strong match %.3f to beat service-only weak match %.3f", strongScore.Score, weakScore.Score)
+	}
+}
+
+func testIncidentNode(t *testing.T, label string, props map[string]any) *Node {
+	t.Helper()
+
+	var raw json.RawMessage
+	if props != nil {
+		encoded, err := json.Marshal(props)
+		if err != nil {
+			t.Fatalf("marshal properties: %v", err)
+		}
+		raw = encoded
+	}
+
+	return &Node{
+		ID:         uuid.New(),
+		TeamID:     uuid.New(),
+		Type:       NodeTypeIncident,
+		Status:     NodeStatusPermanent,
+		Label:      label,
+		Properties: raw,
+	}
+}


### PR DESCRIPTION
## Summary

Closes #36.

This PR adds the first backend implementation of smarter incident similarity matching on top of the incident knowledge graph foundation from #35/#39.

It adds:

- `PostgresStore`, a Postgres-backed implementation of the `graph.Store` interface
- metadata-aware `FindSimilar` support for incident nodes
- weighted similarity scoring across:
  - alert title
  - root cause text
  - log patterns
  - affected service
  - metric anomalies
  - commits/deployments
  - previous resolution
- similarity score and human-readable reason output through the existing `SimilarNode` type
- unit tests for the scoring logic
- optional integration tests for the Postgres-backed graph store

## Why

When an alert fires, Wachd should be able to say:

> This looks like a previous incident. Here is how similar it is and why it matched.

This makes the graph immediately useful to responders and creates the backend path for showing previous root causes, resolutions, affected services, and timestamps in the UI later.

## Notes

This implementation intentionally does not add a pgvector dependency yet. The current schema does not have an embedding/vector column, so this PR adds a deterministic metadata-aware matcher first. The scoring logic is isolated so it can be replaced or extended with pgvector/embedding similarity later without changing the `FindSimilar` API.



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

## Tests

```bash
go test ./internal/graph
go test ./...
```

- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

<!-- Closes #<issue number> -->
