### PR TITLE
fix(web,docs): fix Docker Compose proxy and first-run experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,22 @@ make compose-up
 
 > **If you have a local `.env` from development:** `DATABASE_URL` and `REDIS_URL` use `localhost` hostnames, which won't resolve inside Docker. Either remove the `.env` file (the compose defaults use Docker service names) or update those two values to `postgres:5432` and `redis:6379`.
 
-Open **http://localhost:3000** — the dashboard is running.
+**First run — get your admin credentials:**
+
+On the very first startup, Wachd creates a superadmin account and prints the credentials once to the server log. Retrieve them with:
+
+```bash
+docker compose logs wachd-server | grep -A 6 "BOOTSTRAP ADMIN"
+```
+
+You will see:
+
+```
+║  Username: wachd_admin                        ║
+║  Password: <generated-password>               ║
+```
+
+Log in at **http://localhost:3000** and change the password immediately when prompted.
 
 > **Before going to production:** generate a unique encryption key and set it in `.env`:
 > ```bash
@@ -190,6 +205,8 @@ Then `make compose-up` again.
 ```bash
 make compose-down
 ```
+
+> **Why not `docker compose down` directly?** The app services (`wachd-server`, `wachd-worker`, `wachd-web`) use the `app` profile. Running `docker compose down` without `--profile app` skips them, leaving the network in use. Always use `make compose-down` — or `docker compose --profile app down` if you prefer the raw command.
 
 ---
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,27 +1,12 @@
 import type { NextConfig } from "next";
 import path from "path";
 
-const backendURL = process.env.BACKEND_URL ?? "http://localhost:8080";
-
 const nextConfig: NextConfig = {
   output: "standalone",
   turbopack: {
     // Explicitly anchor the project root so Turbopack never walks up past web/
     // and accidentally picks up /Users/<user>/package.json or the repo root.
     root: path.resolve(__dirname),
-  },
-  async rewrites() {
-    return [
-      // Proxy auth flow and all API calls to the Go backend
-      {
-        source: "/auth/:path*",
-        destination: `${backendURL}/auth/:path*`,
-      },
-      {
-        source: "/api/:path*",
-        destination: `${backendURL}/api/:path*`,
-      },
-    ];
   },
 };
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,12 +1,24 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+// Read at server startup from the runtime environment — works correctly in Docker
+// because process.env is populated before the Next.js server module is loaded.
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+
 const PUBLIC_PATHS = ['/login', '/auth/login', '/auth/local/login', '/auth/callback']
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // Allow public paths through unconditionally
+  // Proxy all /auth/* and /api/* requests to the Go backend.
+  // Evaluated at runtime so BACKEND_URL is always the container-resolved value.
+  if (pathname.startsWith('/auth/') || pathname.startsWith('/api/')) {
+    const target = new URL(pathname, BACKEND_URL)
+    target.search = request.nextUrl.search
+    return NextResponse.rewrite(target)
+  }
+
+  // Allow public page paths through unconditionally
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
     return NextResponse.next()
   }
@@ -33,6 +45,6 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // Run on all page routes but skip API routes and static files
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|api/).*)'],
+  // Run on all routes except static files; /auth/* and /api/* are handled above
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 }


### PR DESCRIPTION
## Summary

- Fixes login broken for all Docker Compose deployments — `BACKEND_URL` was baked in at build time as `localhost:8080` (#45)
- Documents how to retrieve the bootstrap admin credentials on first run (#46)
- Documents `--profile app` requirement for `docker compose down` (#46)

## Changes

**`web/proxy.ts`**
Moved backend proxying (`/auth/*`, `/api/*`) from `next.config.ts` rewrites to `proxy.ts`. The proxy file runs at server startup and reads `BACKEND_URL` from the live container environment. The existing session check logic is unchanged.

**`web/next.config.ts`**
Removed `rewrites()` and the `backendURL` constant — both replaced by `proxy.ts`.

**`README.md`**
- Added first-run callout: how to retrieve bootstrap admin credentials from the server log after `make compose-up`
- Added note after `make compose-down` explaining why `docker compose down` alone leaves the network in use and what the correct command is

## Test plan

- [ ] `make compose-up` — login page loads and accepts credentials (no ECONNREFUSED)
- [ ] `docker compose logs wachd-server | grep -A 6 "BOOTSTRAP ADMIN"` returns credentials on first run
- [ ] `make compose-down` brings all containers and the network down cleanly

Closes #45
Closes #46