### PR TITLE
fix(store): migrate legacy timestamps to timestamptz

### DIFF
--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -6,8 +6,8 @@ CREATE TABLE IF NOT EXISTS teams (
     id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     name           VARCHAR(255) NOT NULL,
     webhook_secret VARCHAR(255) NOT NULL UNIQUE,
-    created_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at     TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at     TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_teams_webhook_secret ON teams(webhook_secret);
@@ -19,8 +19,8 @@ CREATE TABLE IF NOT EXISTS users (
     email      VARCHAR(255) NOT NULL,
     phone      VARCHAR(50),
     role       VARCHAR(50)  NOT NULL DEFAULT 'responder',
-    created_at TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_team_id ON users(team_id);
@@ -37,13 +37,13 @@ CREATE TABLE IF NOT EXISTS incidents (
     alert_payload JSONB        NOT NULL,
     context       JSONB,
     analysis      JSONB,
-    fired_at         TIMESTAMP NOT NULL DEFAULT NOW(),
-    acknowledged_at  TIMESTAMP,
-    resolved_at      TIMESTAMP,
-    snoozed_until    TIMESTAMP,
+    fired_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    acknowledged_at  TIMESTAMPTZ,
+    resolved_at      TIMESTAMPTZ,
+    snoozed_until    TIMESTAMPTZ,
     escalation_step  INT NOT NULL DEFAULT 0,
-    created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     assigned_to   UUID REFERENCES users(id)
 );
 ALTER TABLE incidents ADD COLUMN IF NOT EXISTS escalation_step INT NOT NULL DEFAULT 0;
@@ -59,8 +59,8 @@ CREATE TABLE IF NOT EXISTS schedules (
     name            VARCHAR(255) NOT NULL,
     rotation_config JSONB        NOT NULL,
     enabled         BOOLEAN      NOT NULL DEFAULT true,
-    created_at      TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at      TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_schedules_team_id ON schedules(team_id);
@@ -74,8 +74,8 @@ CREATE TABLE IF NOT EXISTS sso_identities (
     email       VARCHAR(255) NOT NULL,
     name        VARCHAR(255) NOT NULL,
     avatar_url  VARCHAR(500),
-    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
     UNIQUE(provider, provider_id)
 );
 
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS group_mappings (
     group_name  VARCHAR(255),                    -- human-readable label
     team_id     UUID         NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
     role        VARCHAR(50)  NOT NULL DEFAULT 'viewer',
-    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
     UNIQUE(provider, group_id, team_id)
 );
 
@@ -108,9 +108,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     id          UUID     PRIMARY KEY DEFAULT gen_random_uuid(),
     identity_id UUID     NOT NULL REFERENCES sso_identities(id) ON DELETE CASCADE,
     token_hash  CHAR(64) NOT NULL UNIQUE,        -- SHA-256 hex of session token
-    expires_at  TIMESTAMP NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
     ip_address  VARCHAR(45),
-    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_token_hash ON sessions(token_hash);
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS password_policy (
     require_special          BOOLEAN     NOT NULL DEFAULT true,
     max_failed_attempts      INT         NOT NULL DEFAULT 5,
     lockout_duration_minutes INT         NOT NULL DEFAULT 30,
-    updated_at               TIMESTAMP   NOT NULL DEFAULT NOW()
+    updated_at               TIMESTAMPTZ   NOT NULL DEFAULT NOW()
 );
 INSERT INTO password_policy (id) VALUES (1) ON CONFLICT DO NOTHING;
 
@@ -144,10 +144,10 @@ CREATE TABLE IF NOT EXISTS local_users (
     is_active             BOOLEAN      NOT NULL DEFAULT true,
     force_password_change BOOLEAN      NOT NULL DEFAULT false,
     failed_login_attempts INT          NOT NULL DEFAULT 0,
-    locked_until          TIMESTAMP,
-    last_login_at         TIMESTAMP,
-    created_at            TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at            TIMESTAMP    NOT NULL DEFAULT NOW()
+    locked_until          TIMESTAMPTZ,
+    last_login_at         TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_local_users_username ON local_users(username);
 CREATE INDEX IF NOT EXISTS idx_local_users_email    ON local_users(email);
@@ -157,15 +157,15 @@ CREATE TABLE IF NOT EXISTS local_groups (
     id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     name        VARCHAR(255) NOT NULL UNIQUE,
     description TEXT,
-    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 -- Local group membership (user → group many-to-many)
 CREATE TABLE IF NOT EXISTS local_group_members (
     group_id   UUID      NOT NULL REFERENCES local_groups(id) ON DELETE CASCADE,
     user_id    UUID      NOT NULL REFERENCES local_users(id)  ON DELETE CASCADE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (group_id, user_id)
 );
 CREATE INDEX IF NOT EXISTS idx_local_group_members_user ON local_group_members(user_id);
@@ -190,8 +190,8 @@ CREATE TABLE IF NOT EXISTS sso_providers (
     scopes            TEXT[]       NOT NULL DEFAULT ARRAY['openid','profile','email'],
     enabled           BOOLEAN      NOT NULL DEFAULT true,
     auto_provision    BOOLEAN      NOT NULL DEFAULT true,
-    created_at        TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at        TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_sso_providers_enabled ON sso_providers(enabled);
 
@@ -218,9 +218,9 @@ CREATE TABLE IF NOT EXISTS api_tokens (
     user_id      UUID         NOT NULL REFERENCES local_users(id) ON DELETE CASCADE,
     name         VARCHAR(255) NOT NULL,
     token_hash   CHAR(64)     NOT NULL UNIQUE,  -- SHA-256 hex of the raw token
-    last_used_at TIMESTAMP,
-    expires_at   TIMESTAMP,                      -- NULL = never expires
-    created_at   TIMESTAMP    NOT NULL DEFAULT NOW()
+    last_used_at TIMESTAMPTZ,
+    expires_at   TIMESTAMPTZ,                      -- NULL = never expires
+    created_at   TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
@@ -236,12 +236,12 @@ CREATE TABLE IF NOT EXISTS schedule_overrides (
     id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     schedule_id UUID         NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
     team_id     UUID         NOT NULL,  -- denormalized for fast team-scoped queries
-    start_at    TIMESTAMP    NOT NULL,
-    end_at      TIMESTAMP    NOT NULL,
+    start_at    TIMESTAMPTZ    NOT NULL,
+    end_at      TIMESTAMPTZ    NOT NULL,
     user_id     UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     reason      TEXT,
     created_by  UUID         NOT NULL,  -- local_users.id or users.id of the creator
-    created_at  TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_schedule_overrides_schedule ON schedule_overrides(schedule_id);
 CREATE INDEX IF NOT EXISTS idx_schedule_overrides_team     ON schedule_overrides(team_id);
@@ -252,7 +252,7 @@ CREATE TABLE IF NOT EXISTS escalation_policies (
     id         UUID      PRIMARY KEY DEFAULT gen_random_uuid(),
     team_id    UUID      NOT NULL UNIQUE REFERENCES teams(id) ON DELETE CASCADE,
     config     JSONB     NOT NULL,
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_escalation_policies_team ON escalation_policies(team_id);
 
@@ -289,8 +289,8 @@ CREATE TABLE IF NOT EXISTS team_config (
     dynatrace_token_encrypted   TEXT,
     splunk_endpoint             VARCHAR(500),
     splunk_token_encrypted      TEXT,
-    created_at             TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at             TIMESTAMP    NOT NULL DEFAULT NOW()
+    created_at             TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 -- Idempotent migration: add Dynatrace and Splunk columns if they don't exist yet.
@@ -348,7 +348,7 @@ CREATE TABLE IF NOT EXISTS system_config (
     id          INT          PRIMARY KEY DEFAULT 1 CHECK (id = 1),
     ai_backend  VARCHAR(50)  NOT NULL DEFAULT 'ollama',
     ai_model    VARCHAR(100),
-    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
     updated_by  UUID         REFERENCES local_users(id) ON DELETE SET NULL
 );
 
@@ -417,3 +417,89 @@ CREATE TABLE IF NOT EXISTS graph_edges (
 CREATE INDEX IF NOT EXISTS idx_graph_edges_team ON graph_edges(team_id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_from ON graph_edges(from_id);
 CREATE INDEX IF NOT EXISTS idx_graph_edges_to   ON graph_edges(to_id);
+
+-- ============================================================
+-- Issue #25: migrate legacy TIMESTAMP columns to TIMESTAMPTZ
+-- ============================================================
+-- Existing databases may still have older columns created as TIMESTAMP
+-- WITHOUT TIME ZONE. Go already writes UTC values and the DB connection forces
+-- UTC sessions, so reinterpret existing values as UTC during the type change.
+--
+-- The information_schema guard keeps this migration idempotent: once a column
+-- is already TIMESTAMPTZ, it is skipped on future startup migrations.
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN
+        SELECT c.table_name, c.column_name
+        FROM (VALUES
+            ('teams', 'created_at'),
+            ('teams', 'updated_at'),
+
+            ('users', 'created_at'),
+            ('users', 'updated_at'),
+
+            ('incidents', 'fired_at'),
+            ('incidents', 'acknowledged_at'),
+            ('incidents', 'resolved_at'),
+            ('incidents', 'snoozed_until'),
+            ('incidents', 'created_at'),
+            ('incidents', 'updated_at'),
+
+            ('schedules', 'created_at'),
+            ('schedules', 'updated_at'),
+
+            ('sso_identities', 'created_at'),
+            ('sso_identities', 'updated_at'),
+
+            ('sessions', 'expires_at'),
+            ('sessions', 'created_at'),
+
+            ('password_policy', 'updated_at'),
+
+            ('local_users', 'locked_until'),
+            ('local_users', 'last_login_at'),
+            ('local_users', 'created_at'),
+            ('local_users', 'updated_at'),
+
+            ('local_groups', 'created_at'),
+            ('local_groups', 'updated_at'),
+
+            ('local_group_members', 'created_at'),
+
+            ('group_mappings', 'created_at'),
+
+            ('sso_providers', 'created_at'),
+            ('sso_providers', 'updated_at'),
+
+            ('api_tokens', 'last_used_at'),
+            ('api_tokens', 'expires_at'),
+            ('api_tokens', 'created_at'),
+
+            ('schedule_overrides', 'start_at'),
+            ('schedule_overrides', 'end_at'),
+            ('schedule_overrides', 'created_at'),
+
+            ('escalation_policies', 'updated_at'),
+
+            ('team_config', 'created_at'),
+            ('team_config', 'updated_at'),
+
+            ('system_config', 'updated_at')
+        ) AS issue25_legacy_timestamp_columns(table_name, column_name)
+        JOIN information_schema.columns c
+          ON c.table_schema = current_schema()
+         AND c.table_name = issue25_legacy_timestamp_columns.table_name
+         AND c.column_name = issue25_legacy_timestamp_columns.column_name
+        WHERE c.data_type = 'timestamp without time zone'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I ALTER COLUMN %I TYPE TIMESTAMPTZ USING %I AT TIME ZONE ''UTC''',
+            r.table_name,
+            r.column_name,
+            r.column_name
+        );
+    END LOOP;
+END $$;
+

--- a/internal/store/schema_timestamp_test.go
+++ b/internal/store/schema_timestamp_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type issue25TimestampColumn struct {
+	table  string
+	column string
+}
+
+var issue25TimestampColumns = []issue25TimestampColumn{
+	{table: "teams", column: "created_at"},
+	{table: "teams", column: "updated_at"},
+
+	{table: "users", column: "created_at"},
+	{table: "users", column: "updated_at"},
+
+	{table: "incidents", column: "fired_at"},
+	{table: "incidents", column: "acknowledged_at"},
+	{table: "incidents", column: "resolved_at"},
+	{table: "incidents", column: "snoozed_until"},
+	{table: "incidents", column: "created_at"},
+	{table: "incidents", column: "updated_at"},
+
+	{table: "schedules", column: "created_at"},
+	{table: "schedules", column: "updated_at"},
+
+	{table: "sso_identities", column: "created_at"},
+	{table: "sso_identities", column: "updated_at"},
+
+	{table: "sessions", column: "expires_at"},
+	{table: "sessions", column: "created_at"},
+
+	{table: "password_policy", column: "updated_at"},
+
+	{table: "local_users", column: "locked_until"},
+	{table: "local_users", column: "last_login_at"},
+	{table: "local_users", column: "created_at"},
+	{table: "local_users", column: "updated_at"},
+
+	{table: "local_groups", column: "created_at"},
+	{table: "local_groups", column: "updated_at"},
+
+	{table: "local_group_members", column: "created_at"},
+
+	{table: "group_mappings", column: "created_at"},
+
+	{table: "sso_providers", column: "created_at"},
+	{table: "sso_providers", column: "updated_at"},
+
+	{table: "api_tokens", column: "last_used_at"},
+	{table: "api_tokens", column: "expires_at"},
+	{table: "api_tokens", column: "created_at"},
+
+	{table: "schedule_overrides", column: "start_at"},
+	{table: "schedule_overrides", column: "end_at"},
+	{table: "schedule_overrides", column: "created_at"},
+
+	{table: "escalation_policies", column: "updated_at"},
+
+	{table: "team_config", column: "created_at"},
+	{table: "team_config", column: "updated_at"},
+
+	{table: "system_config", column: "updated_at"},
+}
+
+func TestSchemaUsesTimestamptzForColumnTypes(t *testing.T) {
+	sqlWithoutCommentsOrStrings := stripSQLCommentsAndSingleQuotedStrings(schema)
+
+	bareTimestamp := regexp.MustCompile(`(?i)\btimestamp\b`)
+	if loc := bareTimestamp.FindStringIndex(sqlWithoutCommentsOrStrings); loc != nil {
+		start := loc[0] - 80
+		if start < 0 {
+			start = 0
+		}
+
+		end := loc[1] + 80
+		if end > len(sqlWithoutCommentsOrStrings) {
+			end = len(sqlWithoutCommentsOrStrings)
+		}
+
+		t.Fatalf("schema still contains bare TIMESTAMP column type near: %q", sqlWithoutCommentsOrStrings[start:end])
+	}
+}
+
+func TestSchemaIncludesIssue25TimestampMigration(t *testing.T) {
+	if !strings.Contains(schema, "issue25_legacy_timestamp_columns") {
+		t.Fatal("expected issue #25 legacy timestamp migration block")
+	}
+
+	if !strings.Contains(schema, "c.data_type = 'timestamp without time zone'") {
+		t.Fatal("expected migration to only target timestamp without time zone columns")
+	}
+
+	if !strings.Contains(schema, "TYPE TIMESTAMPTZ USING %I AT TIME ZONE ''UTC''") {
+		t.Fatal("expected migration to reinterpret existing timestamp values as UTC")
+	}
+
+	for _, column := range issue25TimestampColumns {
+		want := fmt.Sprintf("('%s', '%s')", column.table, column.column)
+		if !strings.Contains(schema, want) {
+			t.Errorf("issue #25 migration missing %s.%s", column.table, column.column)
+		}
+	}
+}
+
+func stripSQLCommentsAndSingleQuotedStrings(sql string) string {
+	var withoutComments strings.Builder
+
+	for _, line := range strings.Split(sql, "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+
+		withoutComments.WriteString(line)
+		withoutComments.WriteByte('\n')
+	}
+
+	var out strings.Builder
+	inString := false
+	text := withoutComments.String()
+
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+
+		if inString {
+			if ch == '\'' {
+				if i+1 < len(text) && text[i+1] == '\'' {
+					out.WriteByte(' ')
+					i++
+					continue
+				}
+
+				inString = false
+			}
+
+			out.WriteByte(' ')
+			continue
+		}
+
+		if ch == '\'' {
+			inString = true
+			out.WriteByte(' ')
+			continue
+		}
+
+		out.WriteByte(ch)
+	}
+
+	return out.String()
+}


### PR DESCRIPTION
## Summary

Closes #25.

This PR migrates legacy PostgreSQL `TIMESTAMP` columns to `TIMESTAMPTZ` across the store schema.

It updates `internal/store/schema.sql` so:

- fresh databases create timestamp columns as `TIMESTAMPTZ`
- existing databases migrate old `timestamp without time zone` columns to `TIMESTAMPTZ`
- existing timestamp values are reinterpreted as UTC using `AT TIME ZONE 'UTC'`
- the migration is idempotent and only alters columns that are still `timestamp without time zone`

## Why

The Go code already writes UTC timestamps and the DB connection forces the session timezone to UTC. This PR brings the database schema in line with that behavior.

## Implementation notes

Instead of running unconditional `ALTER TABLE ... TYPE TIMESTAMPTZ` statements on every startup, this PR adds a guarded migration block that checks `information_schema.columns`.

That means repeat calls to `Migrate()` do not keep rewriting already-migrated `TIMESTAMPTZ` columns.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

Added schema-level tests that verify:

- the schema no longer contains bare `TIMESTAMP` column types
- the issue #25 migration block includes every expected legacy timestamp column
- the migration uses `AT TIME ZONE 'UTC'`
- the migration only targets `timestamp without time zone` columns

Commands run:

```bash
go test ./internal/store -run TestSchema
go test ./internal/store
go test ./...
make test
go build ./...
go vet ./...
```
- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

<!-- Closes #<issue number> -->
