### PR TITLE
feat(graph): write resolved incidents to graph in worker

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1255,6 +1255,9 @@ func (s *Server) handleResolveIncident(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to resolve incident", http.StatusInternalServerError)
 		return
 	}
+	if err := s.queue.EnqueueIncidentResolved(r.Context(), incidentID, teamID); err != nil {
+		log.Printf("Failed to enqueue resolved incident job: %v", err)
+	}
 
 	log.Printf("✓ Incident %s resolved", incident.Title)
 

--- a/cmd/worker/graph.go
+++ b/cmd/worker/graph.go
@@ -28,6 +28,11 @@ import (
 	"github.com/wachd/wachd/internal/store"
 )
 
+const (
+	maxGraphLogLines = 3
+	maxGraphCommits  = 2
+)
+
 type teamGraphConfigReader interface {
 	GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*store.TeamGraphConfig, error)
 }
@@ -54,6 +59,8 @@ func persistResolvedIncidentNode(ctx context.Context, cfgStore teamGraphConfigRe
 		log.Printf("warn: load team graph config for %s: %v", teamID, err)
 		return nil
 	}
+	// min_similarity_score is intentionally unused on the write path; it applies
+	// when FindSimilar reads back permanent nodes.
 	if cfg != nil && !cfg.Enabled {
 		return nil
 	}
@@ -134,11 +141,6 @@ func (w *Worker) loadIncidentAnalysis(incident *store.Incident) *ai.AnalysisResp
 		log.Printf("warn: parse incident analysis for %s: %v", incident.ID, err)
 		return nil
 	}
-	analysis.RootCause = w.sanitiseGraphValue("", analysis.RootCause)
-	analysis.SuggestedAction = w.sanitiseGraphValue("", analysis.SuggestedAction)
-	for i, finding := range analysis.KeyFindings {
-		analysis.KeyFindings[i] = w.sanitiseGraphValue("", finding)
-	}
 	return &analysis
 }
 
@@ -169,7 +171,7 @@ func summarizeLogPattern(logs []collector.LogLine) string {
 		return ""
 	}
 	seen := make(map[string]struct{}, len(logs))
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, maxGraphLogLines)
 	for _, entry := range logs {
 		msg := strings.TrimSpace(entry.Message)
 		if msg == "" {
@@ -180,7 +182,7 @@ func summarizeLogPattern(logs []collector.LogLine) string {
 		}
 		seen[msg] = struct{}{}
 		parts = append(parts, msg)
-		if len(parts) == 3 {
+		if len(parts) == maxGraphLogLines {
 			break
 		}
 	}
@@ -198,7 +200,7 @@ func summarizeDeployment(commits []collector.Commit) string {
 	if len(commits) == 0 {
 		return ""
 	}
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, maxGraphCommits)
 	for _, commit := range commits {
 		msg := strings.TrimSpace(commit.Message)
 		if msg == "" {
@@ -213,7 +215,7 @@ func summarizeDeployment(commits []collector.Commit) string {
 		} else {
 			parts = append(parts, msg)
 		}
-		if len(parts) == 2 {
+		if len(parts) == maxGraphCommits {
 			break
 		}
 	}

--- a/cmd/worker/graph.go
+++ b/cmd/worker/graph.go
@@ -1,0 +1,221 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/collector"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/store"
+)
+
+type teamGraphConfigReader interface {
+	GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*store.TeamGraphConfig, error)
+}
+
+func (w *Worker) writeResolvedIncidentToGraph(ctx context.Context, incident *store.Incident) error {
+	if incident == nil {
+		return nil
+	}
+	sanitizedCtx := w.loadSanitizedIncidentContext(incident)
+	analysis := w.loadIncidentAnalysis(incident)
+
+	return persistResolvedIncidentNode(ctx, w.db, w.graphStore, incident.TeamID, func() (*graph.Node, error) {
+		return w.buildResolvedIncidentNode(incident, sanitizedCtx, analysis)
+	})
+}
+
+func persistResolvedIncidentNode(ctx context.Context, cfgStore teamGraphConfigReader, graphStore graph.Store, teamID uuid.UUID, buildNode func() (*graph.Node, error)) error {
+	if graphStore == nil || cfgStore == nil || teamID == uuid.Nil || buildNode == nil {
+		return nil
+	}
+
+	cfg, err := cfgStore.GetTeamGraphConfig(ctx, teamID)
+	if err != nil {
+		log.Printf("warn: load team graph config for %s: %v", teamID, err)
+		return nil
+	}
+	if cfg != nil && !cfg.Enabled {
+		return nil
+	}
+
+	node, err := buildNode()
+	if err != nil {
+		log.Printf("warn: build resolved graph node for team %s: %v", teamID, err)
+		return nil
+	}
+	if node == nil {
+		return nil
+	}
+
+	created, err := graphStore.UpsertNode(ctx, teamID, node)
+	if err != nil {
+		log.Printf("warn: upsert graph node for team %s: %v", teamID, err)
+		return nil
+	}
+	if err := graphStore.PromoteNode(ctx, teamID, created.ID); err != nil {
+		log.Printf("warn: promote graph node for team %s: %v", teamID, err)
+		return nil
+	}
+
+	log.Printf("✓ Resolved incident graph node promoted for team %s", teamID)
+	return nil
+}
+
+func (w *Worker) buildResolvedIncidentNode(incident *store.Incident, sanitizedCtx *correlator.Context, analysis *ai.AnalysisResponse) (*graph.Node, error) {
+	if incident == nil {
+		return nil, nil
+	}
+	if sanitizedCtx == nil {
+		sanitizedCtx = &correlator.Context{}
+	}
+
+	properties := map[string]any{
+		"root_cause":     w.sanitiseGraphValue("", analysisField(analysis, func(a *ai.AnalysisResponse) string { return a.RootCause })),
+		"log_pattern":    w.sanitiseGraphValue("", summarizeLogPattern(sanitizedCtx.Logs)),
+		"service":        w.sanitiseGraphValue("", w.extractServiceName(incident)),
+		"metric_anomaly": w.sanitiseGraphValue("", summarizeMetricAnomaly(sanitizedCtx.Metrics)),
+		"deployment":     w.sanitiseGraphValue("", summarizeDeployment(sanitizedCtx.Commits)),
+		"resolution":     w.sanitiseGraphValue("", analysisField(analysis, func(a *ai.AnalysisResponse) string { return a.SuggestedAction })),
+	}
+
+	propsJSON, err := json.Marshal(properties)
+	if err != nil {
+		return nil, err
+	}
+
+	externalID := incident.ID.String()
+	return &graph.Node{
+		Type:       graph.NodeTypeIncident,
+		Status:     graph.NodeStatusPending,
+		Label:      w.sanitiseGraphValue("Untitled incident", incident.Title),
+		ExternalID: &externalID,
+		Properties: propsJSON,
+	}, nil
+}
+
+func (w *Worker) loadSanitizedIncidentContext(incident *store.Incident) *correlator.Context {
+	ctx := &correlator.Context{}
+	if incident == nil || len(incident.Context) == 0 {
+		return ctx
+	}
+	if err := json.Unmarshal(incident.Context, ctx); err != nil {
+		log.Printf("warn: parse incident context for %s: %v", incident.ID, err)
+		return &correlator.Context{}
+	}
+	return w.sanitizeContext(ctx)
+}
+
+func (w *Worker) loadIncidentAnalysis(incident *store.Incident) *ai.AnalysisResponse {
+	if incident == nil || len(incident.Analysis) == 0 {
+		return nil
+	}
+	var analysis ai.AnalysisResponse
+	if err := json.Unmarshal(incident.Analysis, &analysis); err != nil {
+		log.Printf("warn: parse incident analysis for %s: %v", incident.ID, err)
+		return nil
+	}
+	analysis.RootCause = w.sanitiseGraphValue("", analysis.RootCause)
+	analysis.SuggestedAction = w.sanitiseGraphValue("", analysis.SuggestedAction)
+	for i, finding := range analysis.KeyFindings {
+		analysis.KeyFindings[i] = w.sanitiseGraphValue("", finding)
+	}
+	return &analysis
+}
+
+func (w *Worker) sanitiseGraphValue(fallback, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	if w.sanitiser != nil {
+		value = w.sanitiser.Sanitise(value)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func analysisField(analysis *ai.AnalysisResponse, getter func(*ai.AnalysisResponse) string) string {
+	if analysis == nil {
+		return ""
+	}
+	return getter(analysis)
+}
+
+func summarizeLogPattern(logs []collector.LogLine) string {
+	if len(logs) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(logs))
+	parts := make([]string, 0, 3)
+	for _, entry := range logs {
+		msg := strings.TrimSpace(entry.Message)
+		if msg == "" {
+			continue
+		}
+		if _, ok := seen[msg]; ok {
+			continue
+		}
+		seen[msg] = struct{}{}
+		parts = append(parts, msg)
+		if len(parts) == 3 {
+			break
+		}
+	}
+	return strings.Join(parts, " | ")
+}
+
+func summarizeMetricAnomaly(metrics []collector.MetricPoint) string {
+	if len(metrics) == 0 {
+		return ""
+	}
+	return formatMetricsSummary(metrics)
+}
+
+func summarizeDeployment(commits []collector.Commit) string {
+	if len(commits) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	for _, commit := range commits {
+		msg := strings.TrimSpace(commit.Message)
+		if msg == "" {
+			continue
+		}
+		sha := strings.TrimSpace(commit.SHA)
+		if len(sha) > 7 {
+			sha = sha[:7]
+		}
+		if sha != "" {
+			parts = append(parts, sha+": "+msg)
+		} else {
+			parts = append(parts, msg)
+		}
+		if len(parts) == 2 {
+			break
+		}
+	}
+	return strings.Join(parts, " | ")
+}

--- a/cmd/worker/graph_integration_test.go
+++ b/cmd/worker/graph_integration_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/collector"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/queue"
+	"github.com/wachd/wachd/internal/sanitiser"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func requireWorkerDB(t *testing.T) *store.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://wachd:wachd_dev_password@localhost:5432/wachd"
+	}
+	db, err := store.NewDB(dsn)
+	if err != nil {
+		t.Skipf("skipping integration test: DB unavailable (%v)", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestWorker_ProcessResolvedIncidentJob_WritesPermanentNode(t *testing.T) {
+	db := requireWorkerDB(t)
+	ctx := context.Background()
+
+	teamA, err := db.CreateTeam(ctx, uniqueGraphName("graph-team-a"), uniqueGraphName("secret-a"))
+	if err != nil {
+		t.Fatalf("CreateTeam A: %v", err)
+	}
+	teamB, err := db.CreateTeam(ctx, uniqueGraphName("graph-team-b"), uniqueGraphName("secret-b"))
+	if err != nil {
+		t.Fatalf("CreateTeam B: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id IN ($1, $2)", teamA.ID, teamB.ID)
+	})
+
+	incident := createResolvedIncidentFixture(t, ctx, db, teamA.ID)
+
+	worker := &Worker{
+		db:         db,
+		sanitiser:  sanitiser.NewSanitiser(),
+		graphStore: graph.NewPostgresStore(db.Pool()),
+	}
+
+	job := &queue.Job{Type: "incident_resolved", IncidentID: incident.ID, TeamID: teamA.ID}
+	if err := worker.processResolvedIncidentJob(ctx, job); err != nil {
+		t.Fatalf("processResolvedIncidentJob first run: %v", err)
+	}
+	if err := worker.processResolvedIncidentJob(ctx, job); err != nil {
+		t.Fatalf("processResolvedIncidentJob second run: %v", err)
+	}
+
+	var nodeID uuid.UUID
+	var status string
+	err = db.Pool().QueryRow(ctx, `
+		SELECT id, status
+		FROM graph_nodes
+		WHERE team_id = $1 AND type = 'incident' AND external_id = $2
+	`, teamA.ID, incident.ID.String()).Scan(&nodeID, &status)
+	if err != nil {
+		t.Fatalf("query graph node: %v", err)
+	}
+	if status != "permanent" {
+		t.Fatalf("expected permanent node, got %q", status)
+	}
+
+	var count int
+	if err := db.Pool().QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM graph_nodes
+		WHERE team_id = $1 AND type = 'incident' AND external_id = $2
+	`, teamA.ID, incident.ID.String()).Scan(&count); err != nil {
+		t.Fatalf("count graph nodes: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one upserted node, got %d", count)
+	}
+
+	if err := db.Pool().QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM graph_nodes
+		WHERE team_id = $1 AND external_id = $2
+	`, teamB.ID, incident.ID.String()).Scan(&count); err != nil {
+		t.Fatalf("cross-team count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no node for other team, got %d", count)
+	}
+}
+
+func createResolvedIncidentFixture(t *testing.T, ctx context.Context, db *store.DB, teamID uuid.UUID) *store.Incident {
+	t.Helper()
+	message := "payments failing for admin@example.com"
+	incident := &store.Incident{
+		TeamID:       teamID,
+		Title:        "Checkout timeout for admin@example.com from 10.0.0.8",
+		Message:      &message,
+		Severity:     "critical",
+		Status:       "resolved",
+		Source:       "grafana",
+		AlertPayload: []byte(`{"tags":{"service":"checkout-api"}}`),
+		FiredAt:      time.Now().UTC().Add(-10 * time.Minute),
+	}
+	if err := db.CreateIncident(ctx, incident); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	sanitizedCtx := &correlator.Context{
+		Commits: []collector.Commit{{SHA: "abcdef1234567", Message: "rollback checkout deployment", Author: "[EMAIL]"}},
+		Logs:    []collector.LogLine{{Timestamp: time.Now().UTC(), Message: "dial tcp [IP]:5432 timeout", Labels: map[string]string{"service": "checkout-api"}}},
+		Metrics: []collector.MetricPoint{{Timestamp: time.Now().UTC(), Value: 95.4}},
+	}
+	analysis := &ai.AnalysisResponse{
+		RootCause:       "database pool exhaustion",
+		SuggestedAction: "rolled back checkout deployment",
+		Confidence:      "high",
+	}
+	ctxJSON, _ := json.Marshal(sanitizedCtx)
+	analysisJSON, _ := json.Marshal(analysis)
+	resolvedAt := time.Now().UTC()
+	if _, err := db.Pool().Exec(ctx, `
+		UPDATE incidents
+		SET status = 'resolved', context = $1, analysis = $2, resolved_at = $3, updated_at = $3
+		WHERE id = $4 AND team_id = $5
+	`, ctxJSON, analysisJSON, resolvedAt, incident.ID, incident.TeamID); err != nil {
+		t.Fatalf("seed resolved incident fields: %v", err)
+	}
+
+	loaded, err := db.GetIncident(ctx, incident.TeamID, incident.ID)
+	if err != nil {
+		t.Fatalf("GetIncident: %v", err)
+	}
+	return loaded
+}
+
+func uniqueGraphName(prefix string) string {
+	return prefix + "-" + uuid.NewString()[:8]
+}

--- a/cmd/worker/graph_test.go
+++ b/cmd/worker/graph_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/collector"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/sanitiser"
+	"github.com/wachd/wachd/internal/store"
+)
+
+type mockGraphStore struct {
+	upsertCalled  bool
+	promoteCalled bool
+	upsertNode    *graph.Node
+	promoteNodeID uuid.UUID
+	upsertErr     error
+	promoteErr    error
+	returnedNode  *graph.Node
+}
+
+func (m *mockGraphStore) UpsertNode(_ context.Context, _ uuid.UUID, n *graph.Node) (*graph.Node, error) {
+	m.upsertCalled = true
+	m.upsertNode = n
+	if m.upsertErr != nil {
+		return nil, m.upsertErr
+	}
+	if m.returnedNode != nil {
+		return m.returnedNode, nil
+	}
+	return &graph.Node{ID: uuid.New()}, nil
+}
+
+func (m *mockGraphStore) UpsertEdge(context.Context, uuid.UUID, *graph.Edge) (*graph.Edge, error) {
+	panic("unexpected call")
+}
+
+func (m *mockGraphStore) GetSubgraph(context.Context, uuid.UUID, uuid.UUID, int) (*graph.Graph, error) {
+	panic("unexpected call")
+}
+
+func (m *mockGraphStore) FindSimilar(context.Context, uuid.UUID, uuid.UUID, int) ([]*graph.SimilarNode, error) {
+	panic("unexpected call")
+}
+
+func (m *mockGraphStore) PromoteNode(_ context.Context, _ uuid.UUID, nodeID uuid.UUID) error {
+	m.promoteCalled = true
+	m.promoteNodeID = nodeID
+	return m.promoteErr
+}
+
+func (m *mockGraphStore) DeleteNode(context.Context, uuid.UUID, uuid.UUID) error {
+	panic("unexpected call")
+}
+
+type mockGraphConfigStore struct {
+	cfg *store.TeamGraphConfig
+	err error
+}
+
+func (m mockGraphConfigStore) GetTeamGraphConfig(context.Context, uuid.UUID) (*store.TeamGraphConfig, error) {
+	return m.cfg, m.err
+}
+
+func TestWorker_BuildResolvedIncidentNode_SanitisesAndMapsProperties(t *testing.T) {
+	w := &Worker{sanitiser: sanitiser.NewSanitiser()}
+	message := "pager triggered for oncall@example.com"
+	incident := &store.Incident{
+		ID:           uuid.New(),
+		TeamID:       uuid.New(),
+		Title:        "Payment timeout for admin@example.com from 10.0.0.4",
+		Message:      &message,
+		Severity:     "critical",
+		Source:       "grafana",
+		AlertPayload: []byte(`{"tags":{"service":"checkout-api 10.0.0.4"}}`),
+	}
+	ctx := &correlator.Context{
+		Commits: []collector.Commit{{SHA: "abcdef123456", Message: "rollback by admin@example.com", Author: "ops@example.com"}},
+		Logs:    []collector.LogLine{{Timestamp: time.Now(), Message: "dial tcp 10.0.0.4:5432 for admin@example.com", Labels: map[string]string{"email": "admin@example.com"}}},
+		Metrics: []collector.MetricPoint{{Timestamp: time.Now(), Value: 91.2}},
+	}
+	analysis := &ai.AnalysisResponse{
+		RootCause:       "DB pool exhausted for admin@example.com",
+		SuggestedAction: "Rollback deploy from 10.0.0.4",
+	}
+
+	node, err := w.buildResolvedIncidentNode(incident, ctx, analysis)
+	if err != nil {
+		t.Fatalf("buildResolvedIncidentNode: %v", err)
+	}
+	if node.Type != graph.NodeTypeIncident {
+		t.Fatalf("expected incident node, got %s", node.Type)
+	}
+	if node.Status != graph.NodeStatusPending {
+		t.Fatalf("expected pending node before promotion, got %s", node.Status)
+	}
+	if strings.Contains(node.Label, "admin@example.com") || strings.Contains(node.Label, "10.0.0.4") {
+		t.Fatalf("expected node label to be sanitised, got %q", node.Label)
+	}
+
+	var props map[string]string
+	if err := json.Unmarshal(node.Properties, &props); err != nil {
+		t.Fatalf("unmarshal properties: %v", err)
+	}
+	for _, key := range []string{"root_cause", "log_pattern", "service", "metric_anomaly", "deployment", "resolution"} {
+		if _, ok := props[key]; !ok {
+			t.Fatalf("missing property %q in %+v", key, props)
+		}
+	}
+	joined := string(node.Properties)
+	for _, raw := range []string{"admin@example.com", "ops@example.com", "10.0.0.4"} {
+		if strings.Contains(joined, raw) {
+			t.Fatalf("properties leaked raw PII %q: %s", raw, joined)
+		}
+	}
+}
+
+func TestPersistResolvedIncidentNode_SkipsWhenGraphDisabled(t *testing.T) {
+	buildCalled := false
+	graphStore := &mockGraphStore{}
+	err := persistResolvedIncidentNode(
+		context.Background(),
+		mockGraphConfigStore{cfg: &store.TeamGraphConfig{Enabled: false}},
+		graphStore,
+		uuid.New(),
+		func() (*graph.Node, error) {
+			buildCalled = true
+			return &graph.Node{Label: "never-called", Type: graph.NodeTypeIncident}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("persistResolvedIncidentNode: %v", err)
+	}
+	if buildCalled {
+		t.Fatal("expected graph node builder to be skipped when graph is disabled")
+	}
+	if graphStore.upsertCalled || graphStore.promoteCalled {
+		t.Fatal("expected no graph writes when graph is disabled")
+	}
+}
+
+func TestPersistResolvedIncidentNode_PromoteErrorDoesNotBubble(t *testing.T) {
+	teamID := uuid.New()
+	graphStore := &mockGraphStore{
+		returnedNode: &graph.Node{ID: uuid.New()},
+		promoteErr:   errors.New("boom"),
+	}
+	err := persistResolvedIncidentNode(
+		context.Background(),
+		mockGraphConfigStore{cfg: &store.TeamGraphConfig{Enabled: true}},
+		graphStore,
+		teamID,
+		func() (*graph.Node, error) {
+			return &graph.Node{Label: "sanitised incident", Type: graph.NodeTypeIncident}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected fail-safe nil error, got %v", err)
+	}
+	if !graphStore.upsertCalled {
+		t.Fatal("expected upsert to be attempted")
+	}
+	if !graphStore.promoteCalled {
+		t.Fatal("expected promote to be attempted")
+	}
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wachd/wachd/internal/ai"
 	"github.com/wachd/wachd/internal/auth"
 	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
 	"github.com/wachd/wachd/internal/notify"
 	"github.com/wachd/wachd/internal/oncall"
 	"github.com/wachd/wachd/internal/queue"
@@ -48,6 +49,7 @@ type Worker struct {
 	voiceNotifier *notify.VoiceNotifier
 	sanitiser     *sanitiser.Sanitiser
 	correlator    *correlator.Correlator
+	graphStore    graph.Store
 	aiBackend     ai.Backend
 }
 
@@ -245,6 +247,7 @@ func main() {
 		voiceNotifier: voiceNotifier,
 		sanitiser:     san,
 		correlator:    cor,
+		graphStore:    graph.NewPostgresStore(db.Pool()),
 		aiBackend:     aiEngine,
 	}
 
@@ -292,6 +295,18 @@ func (w *Worker) processNextJob(ctx context.Context) error {
 	}
 
 	log.Printf("📥 Processing job %s (type: %s, incident: %s)", job.ID, job.Type, job.IncidentID)
+	switch job.Type {
+	case "alert":
+		return w.processAlertJob(ctx, job)
+	case "incident_resolved":
+		return w.processResolvedIncidentJob(ctx, job)
+	default:
+		log.Printf("warn: unknown job type %q for incident %s", job.Type, job.IncidentID)
+		return nil
+	}
+}
+
+func (w *Worker) processAlertJob(ctx context.Context, job *queue.Job) error {
 
 	incident, err := w.db.GetIncident(ctx, job.TeamID, job.IncidentID)
 	if err != nil {
@@ -386,6 +401,23 @@ func (w *Worker) processNextJob(ctx context.Context) error {
 	w.fireTeamSlack(ctx, incident, onCallUser, aiAnalysis)
 
 	log.Printf("✓ Incident %s processed", incident.ID)
+	return nil
+}
+
+func (w *Worker) processResolvedIncidentJob(ctx context.Context, job *queue.Job) error {
+	incident, err := w.db.GetIncident(ctx, job.TeamID, job.IncidentID)
+	if err != nil {
+		log.Printf("warn: resolved graph write skipped, incident lookup failed for %s: %v", job.IncidentID, err)
+		return nil
+	}
+	if incident.Status != "resolved" {
+		log.Printf("warn: resolved graph write skipped for incident %s with status %q", incident.ID, incident.Status)
+		return nil
+	}
+
+	if err := w.writeResolvedIncidentToGraph(ctx, incident); err != nil {
+		log.Printf("warn: graph write failed for resolved incident %s: %v", incident.ID, err)
+	}
 	return nil
 }
 

--- a/internal/oncall/schedule_test.go
+++ b/internal/oncall/schedule_test.go
@@ -55,6 +55,12 @@ func (m *mockConfigStore) GetMemberByID(_ context.Context, _ uuid.UUID) (*store.
 func (m *mockConfigStore) GetEscalationPolicy(_ context.Context, _ uuid.UUID) (*store.EscalationPolicy, error) {
 	return m.escalationPolicy, nil
 }
+func (m *mockConfigStore) GetTeamGraphConfig(_ context.Context, _ uuid.UUID) (*store.TeamGraphConfig, error) {
+	return &store.TeamGraphConfig{Enabled: true, MinSimilarityScore: 0.12}, nil
+}
+func (m *mockConfigStore) UpsertTeamGraphConfig(_ context.Context, _ *store.TeamGraphConfig) error {
+	return nil
+}
 
 // Unused interface methods — return zero values.
 func (m *mockConfigStore) GetTeam(_ context.Context, _ uuid.UUID) (*store.Team, error) {

--- a/internal/queue/redis.go
+++ b/internal/queue/redis.go
@@ -40,7 +40,9 @@ type Job struct {
 }
 
 const (
-	alertQueueKey = "wachd:queue:alerts"
+	alertQueueKey           = "wachd:queue:alerts"
+	jobTypeAlert            = "alert"
+	jobTypeIncidentResolved = "incident_resolved"
 )
 
 // NewQueue creates a new queue client
@@ -70,9 +72,18 @@ func (q *Queue) Close() error {
 
 // EnqueueAlert enqueues an alert processing job
 func (q *Queue) EnqueueAlert(ctx context.Context, incidentID, teamID uuid.UUID, payload []byte) error {
+	return q.enqueueJob(ctx, jobTypeAlert, incidentID, teamID, payload)
+}
+
+// EnqueueIncidentResolved enqueues a resolved-incident graph processing job.
+func (q *Queue) EnqueueIncidentResolved(ctx context.Context, incidentID, teamID uuid.UUID) error {
+	return q.enqueueJob(ctx, jobTypeIncidentResolved, incidentID, teamID, nil)
+}
+
+func (q *Queue) enqueueJob(ctx context.Context, jobType string, incidentID, teamID uuid.UUID, payload []byte) error {
 	job := Job{
 		ID:         uuid.New().String(),
-		Type:       "alert",
+		Type:       jobType,
 		IncidentID: incidentID,
 		TeamID:     teamID,
 		Payload:    payload,

--- a/internal/queue/redis_test.go
+++ b/internal/queue/redis_test.go
@@ -95,7 +95,7 @@ func TestEnqueueAndDequeue(t *testing.T) {
 	}
 
 	// Verify job fields
-	if job.Type != "alert" {
+	if job.Type != jobTypeAlert {
 		t.Errorf("expected type 'alert', got %q", job.Type)
 	}
 	if job.IncidentID != incidentID {
@@ -112,6 +112,32 @@ func TestEnqueueAndDequeue(t *testing.T) {
 	}
 	if job.CreatedAt.IsZero() {
 		t.Error("expected non-zero CreatedAt")
+	}
+}
+
+func TestEnqueueResolvedIncidentJob(t *testing.T) {
+	q := requireQueue(t)
+	ctx := context.Background()
+
+	incidentID := uuid.New()
+	teamID := uuid.New()
+
+	if err := q.EnqueueIncidentResolved(ctx, incidentID, teamID); err != nil {
+		t.Fatalf("EnqueueIncidentResolved: %v", err)
+	}
+
+	job, err := q.DequeueAlert(ctx, time.Second)
+	if err != nil {
+		t.Fatalf("DequeueAlert: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected a job, got nil")
+	}
+	if job.Type != jobTypeIncidentResolved {
+		t.Fatalf("expected type %q, got %q", jobTypeIncidentResolved, job.Type)
+	}
+	if len(job.Payload) != 0 {
+		t.Fatalf("expected empty payload for resolved job, got %q", job.Payload)
 	}
 }
 

--- a/internal/store/config_store.go
+++ b/internal/store/config_store.go
@@ -61,6 +61,10 @@ type ConfigStore interface {
 	GetEscalationPolicy(ctx context.Context, teamID uuid.UUID) (*EscalationPolicy, error)
 	UpsertEscalationPolicy(ctx context.Context, p *EscalationPolicy) error
 
+	// Team graph config
+	GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*TeamGraphConfig, error)
+	UpsertTeamGraphConfig(ctx context.Context, cfg *TeamGraphConfig) error
+
 	// User notification rules
 	ListUserNotificationRules(ctx context.Context, userID uuid.UUID, userSource string) ([]*UserNotificationRule, error)
 	GetUserNotificationRules(ctx context.Context, userID uuid.UUID, userSource, eventType string) ([]*UserNotificationRule, error)

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -96,6 +96,14 @@ type EscalationPolicy struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// TeamGraphConfig controls incident graph write/search behavior per team.
+type TeamGraphConfig struct {
+	TeamID             uuid.UUID `json:"team_id"`
+	Enabled            bool      `json:"enabled"`
+	MinSimilarityScore float64   `json:"min_similarity_score"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
 // SSOIdentity is a provider-level identity (one per person, not per team)
 type SSOIdentity struct {
 	ID         uuid.UUID  `json:"id"`

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -340,6 +340,18 @@ CREATE INDEX IF NOT EXISTS idx_pending_notif_fire ON pending_notifications(sched
     WHERE sent_at IS NULL AND cancelled_at IS NULL;
 
 -- ============================================================
+-- Team graph configuration
+-- Controls whether resolved incidents are written to the knowledge graph and
+-- what minimum similarity score should be used for retrieval.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS team_graph_config (
+    team_id              UUID PRIMARY KEY REFERENCES teams(id) ON DELETE CASCADE,
+    enabled              BOOLEAN     NOT NULL DEFAULT true,
+    min_similarity_score FLOAT       NOT NULL DEFAULT 0.12,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ============================================================
 -- Platform-wide system configuration (superadmin only)
 -- Singleton row: always use id = 1.
 -- ============================================================

--- a/internal/store/store_extended_test.go
+++ b/internal/store/store_extended_test.go
@@ -901,6 +901,51 @@ func TestDB_TeamConfig_GetAndUpsert(t *testing.T) {
 	}
 }
 
+func TestDB_TeamGraphConfig_GetAndUpsert(t *testing.T) {
+	db := requireDB(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, unique("graph-team"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	t.Cleanup(func() { _ = db.DeleteTeam(ctx, team.ID) })
+
+	defaults, err := db.GetTeamGraphConfig(ctx, team.ID)
+	if err != nil {
+		t.Fatalf("GetTeamGraphConfig defaults: %v", err)
+	}
+	if defaults == nil {
+		t.Fatal("expected default graph config")
+	}
+	if !defaults.Enabled {
+		t.Fatal("expected default graph config to be enabled")
+	}
+	if defaults.MinSimilarityScore != defaultTeamGraphMinSimilarityScore {
+		t.Fatalf("expected default similarity score %.2f, got %.2f", defaultTeamGraphMinSimilarityScore, defaults.MinSimilarityScore)
+	}
+
+	cfg := &TeamGraphConfig{
+		TeamID:             team.ID,
+		Enabled:            false,
+		MinSimilarityScore: 0.42,
+	}
+	if err := db.UpsertTeamGraphConfig(ctx, cfg); err != nil {
+		t.Fatalf("UpsertTeamGraphConfig insert: %v", err)
+	}
+
+	got, err := db.GetTeamGraphConfig(ctx, team.ID)
+	if err != nil {
+		t.Fatalf("GetTeamGraphConfig: %v", err)
+	}
+	if got.Enabled {
+		t.Fatal("expected graph config to be disabled after update")
+	}
+	if got.MinSimilarityScore != cfg.MinSimilarityScore {
+		t.Fatalf("expected similarity score %.2f, got %.2f", cfg.MinSimilarityScore, got.MinSimilarityScore)
+	}
+}
+
 // ── Team Members ──────────────────────────────────────────────────────────────
 
 func TestDB_GetTeamMembers_ViaGroupAccess(t *testing.T) {

--- a/internal/store/team_graph_config.go
+++ b/internal/store/team_graph_config.go
@@ -1,0 +1,78 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const defaultTeamGraphMinSimilarityScore = 0.12
+
+// GetTeamGraphConfig returns the graph configuration for a team.
+// If no explicit row exists yet, defaults are returned.
+func (db *DB) GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*TeamGraphConfig, error) {
+	var cfg TeamGraphConfig
+	err := db.pool.QueryRow(ctx, `
+		SELECT team_id, enabled, min_similarity_score, updated_at
+		FROM team_graph_config
+		WHERE team_id = $1
+	`, teamID).Scan(&cfg.TeamID, &cfg.Enabled, &cfg.MinSimilarityScore, &cfg.UpdatedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return &TeamGraphConfig{
+				TeamID:             teamID,
+				Enabled:            true,
+				MinSimilarityScore: defaultTeamGraphMinSimilarityScore,
+			}, nil
+		}
+		return nil, fmt.Errorf("get team graph config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// UpsertTeamGraphConfig creates or updates the team graph configuration.
+func (db *DB) UpsertTeamGraphConfig(ctx context.Context, cfg *TeamGraphConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("team graph config is required")
+	}
+	if cfg.TeamID == uuid.Nil {
+		return fmt.Errorf("team id is required")
+	}
+	if cfg.MinSimilarityScore < 0 || cfg.MinSimilarityScore > 1 {
+		return fmt.Errorf("min similarity score must be between 0 and 1")
+	}
+	if cfg.UpdatedAt.IsZero() {
+		cfg.UpdatedAt = time.Now().UTC()
+	}
+
+	_, err := db.pool.Exec(ctx, `
+		INSERT INTO team_graph_config (team_id, enabled, min_similarity_score, updated_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (team_id)
+		DO UPDATE SET
+			enabled = EXCLUDED.enabled,
+			min_similarity_score = EXCLUDED.min_similarity_score,
+			updated_at = EXCLUDED.updated_at
+	`, cfg.TeamID, cfg.Enabled, cfg.MinSimilarityScore, cfg.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert team graph config: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Addresses #41

This wires the incident similarity graph end-to-end by writing resolved incidents into the graph store.

What changed
- Added `team_graph_config` table (enabled + min_similarity_score) and store accessors.
- Enqueued an `incident_resolved` worker job from the incident resolve API handler.
- Worker initializes `graph.PostgresStore` and, on resolved jobs:
  - builds a sanitized incident node (label + properties)
  - upserts by external_id (incident ID)
  - promotes node to permanent (fail-safe on errors)
- Added unit tests for node mapping + config gating + fail-safe behavior.
- Added DB-backed integration test (skips if Postgres is unavailable).

Verification
- `go test ./...`
- Note: the Postgres-backed worker integration test requires a running DB (uses `TEST_DATABASE_URL` or defaults to localhost:5432).