### PR TITLE
feat(collector): add service dependency context collection

### DIFF
--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -794,3 +794,75 @@ func TestE2E_UpdateMember_UserMustBeTeamMember(t *testing.T) {
 		t.Errorf("phone update for non-member: got %d, want 422", resp.Code)
 	}
 }
+
+// TestE2E_ServiceDependencies_FilterByService verifies that GET
+// /api/v1/teams/{teamId}/dependencies?service=<name> returns only dependencies
+// where service matches, and that omitting the filter returns all dependencies.
+func TestE2E_ServiceDependencies_FilterByService(t *testing.T) {
+	env := newE2EEnv(t)
+
+	createDep := func(service, dependsOn string) {
+		t.Helper()
+		req := httptest.NewRequest("POST",
+			fmt.Sprintf("/api/v1/teams/%s/dependencies", env.kongTeam.ID),
+			e2eBody(t, map[string]any{"service": service, "depends_on": dependsOn}))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(env.kongCookie)
+		resp := env.do(req)
+		if resp.Code != http.StatusCreated {
+			t.Fatalf("create dep %s→%s: got %d, want 201", service, dependsOn, resp.Code)
+		}
+	}
+
+	createDep("checkout-api", "redis-cache")
+	createDep("checkout-api", "payments-db")
+	createDep("payments-service", "postgres")
+
+	listDeps := func(serviceFilter string) []map[string]any {
+		t.Helper()
+		url := fmt.Sprintf("/api/v1/teams/%s/dependencies", env.kongTeam.ID)
+		if serviceFilter != "" {
+			url += "?service=" + serviceFilter
+		}
+		req := httptest.NewRequest("GET", url, nil)
+		req.AddCookie(env.kongCookie)
+		resp := env.do(req)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("list deps (filter=%q): got %d, want 200", serviceFilter, resp.Code)
+		}
+		var deps []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&deps); err != nil {
+			t.Fatalf("decode deps: %v", err)
+		}
+		return deps
+	}
+
+	// No filter — all three deps returned.
+	all := listDeps("")
+	if len(all) < 3 {
+		t.Errorf("expected at least 3 deps with no filter, got %d", len(all))
+	}
+
+	// Filter by checkout-api — only its two deps returned.
+	checkoutDeps := listDeps("checkout-api")
+	if len(checkoutDeps) != 2 {
+		t.Errorf("expected 2 deps for checkout-api, got %d", len(checkoutDeps))
+	}
+	for _, d := range checkoutDeps {
+		if d["service"] != "checkout-api" {
+			t.Errorf("filter returned dep with service=%q, want checkout-api", d["service"])
+		}
+	}
+
+	// Filter by payments-service — only its one dep returned.
+	paymentsDeps := listDeps("payments-service")
+	if len(paymentsDeps) != 1 {
+		t.Errorf("expected 1 dep for payments-service, got %d", len(paymentsDeps))
+	}
+
+	// Filter by a depends_on value — should return nothing (filter is on service, not depends_on).
+	redisDeps := listDeps("redis-cache")
+	if len(redisDeps) != 0 {
+		t.Errorf("filter by depends_on value should return 0 results, got %d", len(redisDeps))
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -596,6 +596,9 @@ func main() {
 	apiRouter.HandleFunc("/{teamId}/config/test-notification", server.handleTestNotification).Methods("POST")
 	apiRouter.HandleFunc("/{teamId}/escalation", server.handleGetEscalationPolicy).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/escalation", server.handleUpsertEscalationPolicy).Methods("PUT")
+	apiRouter.HandleFunc("/{teamId}/dependencies", server.handleListServiceDependencies).Methods("GET")
+	apiRouter.HandleFunc("/{teamId}/dependencies", server.handleCreateServiceDependency).Methods("POST")
+	apiRouter.HandleFunc("/{teamId}/dependencies/{depId}", server.handleDeleteServiceDependency).Methods("DELETE")
 
 	// Wrap router with CORS middleware
 	handler := corsMiddleware(router)
@@ -2550,4 +2553,89 @@ func sessionIdentity(sess *auth.Session) (uuid.UUID, string) {
 		return *sess.IdentityID, "sso"
 	}
 	return uuid.Nil, "local"
+}
+
+// ── Service Dependencies ──────────────────────────────────────────────────────
+
+func (s *Server) handleListServiceDependencies(w http.ResponseWriter, r *http.Request) {
+	teamID, err := uuid.Parse(mux.Vars(r)["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAccess(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	deps, err := s.cfg.ListServiceDependencies(r.Context(), teamID, "")
+	if err != nil {
+		log.Printf("handleListServiceDependencies: %v", err)
+		http.Error(w, "failed to list service dependencies", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(deps)
+}
+
+func (s *Server) handleCreateServiceDependency(w http.ResponseWriter, r *http.Request) {
+	teamID, err := uuid.Parse(mux.Vars(r)["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	var input struct {
+		Service   string  `json:"service"`
+		DependsOn string  `json:"depends_on"`
+		Label     *string `json:"label"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if input.Service == "" || input.DependsOn == "" {
+		http.Error(w, "service and depends_on are required", http.StatusBadRequest)
+		return
+	}
+	created, err := s.cfg.CreateServiceDependency(r.Context(), &store.ServiceDependency{
+		TeamID:    teamID,
+		Service:   input.Service,
+		DependsOn: input.DependsOn,
+		Label:     input.Label,
+	})
+	if err != nil {
+		log.Printf("handleCreateServiceDependency: %v", err)
+		http.Error(w, "failed to create service dependency", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(created)
+}
+
+func (s *Server) handleDeleteServiceDependency(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	depID, err := uuid.Parse(vars["depId"])
+	if err != nil {
+		http.Error(w, "invalid dependency ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	if err := s.cfg.DeleteServiceDependency(r.Context(), teamID, depID); err != nil {
+		log.Printf("handleDeleteServiceDependency: %v", err)
+		http.Error(w, "service dependency not found", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/redis/go-redis/v9"
 	"github.com/wachd/wachd/internal/auth"
 	"github.com/wachd/wachd/internal/license"
@@ -2567,7 +2568,8 @@ func (s *Server) handleListServiceDependencies(w http.ResponseWriter, r *http.Re
 		writeForbidden(w)
 		return
 	}
-	deps, err := s.cfg.ListServiceDependencies(r.Context(), teamID, "")
+	service := strings.TrimSpace(r.URL.Query().Get("service"))
+	deps, err := s.cfg.ListServiceDependencies(r.Context(), teamID, service)
 	if err != nil {
 		log.Printf("handleListServiceDependencies: %v", err)
 		http.Error(w, "failed to list service dependencies", http.StatusInternalServerError)
@@ -2596,17 +2598,28 @@ func (s *Server) handleCreateServiceDependency(w http.ResponseWriter, r *http.Re
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if input.Service == "" || input.DependsOn == "" {
+	service := strings.TrimSpace(input.Service)
+	dependsOn := strings.TrimSpace(input.DependsOn)
+	if service == "" || dependsOn == "" {
 		http.Error(w, "service and depends_on are required", http.StatusBadRequest)
+		return
+	}
+	if strings.EqualFold(service, dependsOn) {
+		http.Error(w, "service cannot depend on itself", http.StatusBadRequest)
 		return
 	}
 	created, err := s.cfg.CreateServiceDependency(r.Context(), &store.ServiceDependency{
 		TeamID:    teamID,
-		Service:   input.Service,
-		DependsOn: input.DependsOn,
+		Service:   service,
+		DependsOn: dependsOn,
 		Label:     input.Label,
 	})
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			http.Error(w, "dependency already exists", http.StatusConflict)
+			return
+		}
 		log.Printf("handleCreateServiceDependency: %v", err)
 		http.Error(w, "failed to create service dependency", http.StatusInternalServerError)
 		return

--- a/cmd/worker/helper.go
+++ b/cmd/worker/helper.go
@@ -223,6 +223,10 @@ func (w *Worker) collectContext(ctx context.Context, incident *store.Incident) *
 		}
 	}
 
+	// Collect context for declared service dependencies (e.g. Redis, Postgres).
+	// Uses the same connectors already configured for the team.
+	w.collectDependencyContext(ctx, incident, cfg, serviceName, since, result)
+
 	return result
 }
 
@@ -272,7 +276,72 @@ func (w *Worker) collectGrafanaMCPContext(ctx context.Context, cfg *store.TeamCo
 	return logsSuccess, metricsSuccess
 }
 
-// sanitizeContext strips PII from all collected context before it touches the AI engine.
+// collectDependencyContext loads declared service dependencies for the alerting service
+// and appends logs and metrics for each dependency to result using the team's existing
+// configured connectors. Errors per dependency are logged and skipped — they never
+// block the primary alert context from being returned.
+func (w *Worker) collectDependencyContext(ctx context.Context, incident *store.Incident, cfg *store.TeamConfig, serviceName string, since time.Time, result *correlator.Context) {
+	deps, err := w.db.ListServiceDependencies(ctx, incident.TeamID, serviceName)
+	if err != nil {
+		log.Printf("  ⚠ Load service dependencies for %s: %v", serviceName, err)
+		return
+	}
+	if len(deps) == 0 {
+		return
+	}
+	log.Printf("  🔗 Collecting context for %d declared dependencies of %s", len(deps), serviceName)
+	applyDependencyContext(ctx, incident, cfg, deps, since, result)
+}
+
+// applyDependencyContext pulls logs and metrics for each declared dependency
+// using the team's configured connectors. Extracted as a pure function so it
+// can be unit tested without a real database.
+// When Grafana MCP is configured, prefer using collectGrafanaMCPContext at the
+// Worker level before calling this for direct Loki/Prometheus fallback per dep.
+func applyDependencyContext(ctx context.Context, incident *store.Incident, cfg *store.TeamConfig, deps []*store.ServiceDependency, since time.Time, result *correlator.Context) {
+	for _, dep := range deps {
+		label := dep.DependsOn
+		if dep.Label != nil && *dep.Label != "" {
+			label = *dep.Label
+		}
+		log.Printf("    → dependency: %s (%s)", dep.DependsOn, label)
+
+		if cfg.LokiEndpoint != nil && *cfg.LokiEndpoint != "" {
+			if err := validate.EndpointURL(*cfg.LokiEndpoint); err != nil {
+				log.Printf("    ⚠ Loki endpoint blocked (SSRF) for dependency %s: %v", dep.DependsOn, err)
+			} else {
+				lc := collector.NewLogsCollector(*cfg.LokiEndpoint)
+				logs, err := lc.FetchErrorLogs(ctx, dep.DependsOn, since, incident.FiredAt, 50)
+				if err != nil {
+					log.Printf("    ⚠ Loki for dependency %s: %v", dep.DependsOn, err)
+				} else if len(logs) > 0 {
+					result.Logs = append(result.Logs, logs...)
+					log.Printf("    ✓ %d error logs from Loki for %s", len(logs), dep.DependsOn)
+				}
+			}
+		}
+
+		if cfg.PrometheusEndpoint != nil && *cfg.PrometheusEndpoint != "" {
+			if err := validate.EndpointURL(*cfg.PrometheusEndpoint); err != nil {
+				log.Printf("    ⚠ Prometheus endpoint blocked (SSRF) for dependency %s: %v", dep.DependsOn, err)
+			} else {
+				mc, err := collector.NewMetricsCollector(*cfg.PrometheusEndpoint)
+				if err != nil {
+					log.Printf("    ⚠ Prometheus client for dependency %s: %v", dep.DependsOn, err)
+				} else {
+					metrics, err := mc.FetchErrorRate(ctx, dep.DependsOn, 30*time.Minute)
+					if err != nil {
+						log.Printf("    ⚠ Prometheus for dependency %s: %v", dep.DependsOn, err)
+					} else if len(metrics) > 0 {
+						result.Metrics = append(result.Metrics, metrics...)
+						log.Printf("    ✓ %d metric points from Prometheus for %s", len(metrics), dep.DependsOn)
+					}
+				}
+			}
+		}
+	}
+}
+
 func (w *Worker) sanitizeContext(ctx *correlator.Context) *correlator.Context {
 	sanitized := &correlator.Context{
 		Commits: make([]collector.Commit, len(ctx.Commits)),

--- a/cmd/worker/helper.go
+++ b/cmd/worker/helper.go
@@ -276,6 +276,10 @@ func (w *Worker) collectGrafanaMCPContext(ctx context.Context, cfg *store.TeamCo
 	return logsSuccess, metricsSuccess
 }
 
+// maxDependencyContextServices caps the number of dependency services whose
+// context is collected per incident, bounding outbound calls on large graphs.
+const maxDependencyContextServices = 10
+
 // collectDependencyContext loads declared service dependencies for the alerting service
 // and appends logs and metrics for each dependency to result using the team's existing
 // configured connectors. Errors per dependency are logged and skipped — they never
@@ -289,8 +293,76 @@ func (w *Worker) collectDependencyContext(ctx context.Context, incident *store.I
 	if len(deps) == 0 {
 		return
 	}
+	if len(deps) > maxDependencyContextServices {
+		log.Printf("  ⚠ %d dependencies for %s — capping collection at %d", len(deps), serviceName, maxDependencyContextServices)
+		deps = deps[:maxDependencyContextServices]
+	}
 	log.Printf("  🔗 Collecting context for %d declared dependencies of %s", len(deps), serviceName)
-	applyDependencyContext(ctx, incident, cfg, deps, since, result)
+
+	// When Grafana MCP is configured, prefer it for each dependency.
+	// Deps where MCP returns an error (not just empty) fall back to direct connectors.
+	var directDeps []*store.ServiceDependency
+	if cfg.GrafanaMCPURL != nil && *cfg.GrafanaMCPURL != "" &&
+		cfg.GrafanaMCPTokenEncrypted != nil && *cfg.GrafanaMCPTokenEncrypted != "" && w.enc != nil {
+		if err := validate.EndpointURL(*cfg.GrafanaMCPURL); err != nil {
+			log.Printf("  ⚠ Grafana MCP endpoint blocked (SSRF) for dependency collection: %v", err)
+			directDeps = deps
+		} else if token, decryptErr := w.enc.Decrypt(*cfg.GrafanaMCPTokenEncrypted); decryptErr != nil {
+			log.Printf("  ⚠ Failed to decrypt Grafana MCP token for dependency collection: %v", decryptErr)
+			directDeps = deps
+		} else if token != "" {
+			mc := newGrafanaMCPCollector(*cfg.GrafanaMCPURL, token)
+			for _, dep := range deps {
+				logsOK, metricsOK := collectDepViaMCP(ctx, mc, dep, since, incident.FiredAt, result)
+				if !logsOK || !metricsOK {
+					directDeps = append(directDeps, dep)
+				}
+			}
+		} else {
+			directDeps = deps
+		}
+	} else {
+		directDeps = deps
+	}
+
+	if len(directDeps) > 0 {
+		applyDependencyContext(ctx, incident, cfg, directDeps, since, result)
+	}
+}
+
+// collectDepViaMCP fetches logs and metrics for a single dependency via Grafana MCP.
+// Returns (logsOK, metricsOK) — true when the call completed without error, even if
+// no data was returned. A successful-but-empty call still marks the connector as
+// handled so the dep is not double-collected via direct Loki/Prometheus.
+func collectDepViaMCP(ctx context.Context, mc grafanaMCPCollector, dep *store.ServiceDependency, since, until time.Time, result *correlator.Context) (bool, bool) {
+	label := dep.DependsOn
+	if dep.Label != nil && *dep.Label != "" {
+		label = *dep.Label
+	}
+
+	logsOK := false
+	if logs, err := mc.FetchErrorLogs(ctx, dep.DependsOn, since, until, 50); err != nil {
+		log.Printf("    ⚠ Grafana MCP logs for dependency %s: %v", dep.DependsOn, err)
+	} else {
+		logsOK = true
+		if len(logs) > 0 {
+			result.Logs = append(result.Logs, logs...)
+			log.Printf("    ✓ %d error logs from Grafana MCP for %s (%s)", len(logs), dep.DependsOn, label)
+		}
+	}
+
+	metricsOK := false
+	if metrics, err := mc.FetchErrorRate(ctx, dep.DependsOn, 30*time.Minute); err != nil {
+		log.Printf("    ⚠ Grafana MCP metrics for dependency %s: %v", dep.DependsOn, err)
+	} else {
+		metricsOK = true
+		if len(metrics) > 0 {
+			result.Metrics = append(result.Metrics, metrics...)
+			log.Printf("    ✓ %d metric points from Grafana MCP for %s (%s)", len(metrics), dep.DependsOn, label)
+		}
+	}
+
+	return logsOK, metricsOK
 }
 
 // applyDependencyContext pulls logs and metrics for each declared dependency

--- a/cmd/worker/service_dependencies_test.go
+++ b/cmd/worker/service_dependencies_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/collector"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func makeDepIncident(teamID uuid.UUID) *store.Incident {
+	return &store.Incident{
+		ID:      uuid.New(),
+		TeamID:  teamID,
+		FiredAt: time.Now().UTC(),
+	}
+}
+
+func TestApplyDependencyContext_NilDepsIsNoop(t *testing.T) {
+	result := &correlator.Context{}
+	incident := makeDepIncident(uuid.New())
+	applyDependencyContext(context.Background(), incident, &store.TeamConfig{}, nil, incident.FiredAt.Add(-30*time.Minute), result)
+	if len(result.Logs) != 0 || len(result.Metrics) != 0 {
+		t.Fatalf("expected empty result for nil deps, got logs=%d metrics=%d", len(result.Logs), len(result.Metrics))
+	}
+}
+
+func TestApplyDependencyContext_NoConnectorsLeavesResultUnchanged(t *testing.T) {
+	// Pre-populate result — with no connectors configured, deps cannot add anything.
+	// Primary data must survive the call unchanged.
+	existing := collector.LogLine{Timestamp: time.Now().UTC(), Message: "primary error"}
+	result := &correlator.Context{Logs: []collector.LogLine{existing}}
+
+	teamID := uuid.New()
+	incident := makeDepIncident(teamID)
+	deps := []*store.ServiceDependency{
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "redis-cache"},
+	}
+
+	// cfg has no Loki/Prometheus endpoints — nothing can be collected for the dep.
+	applyDependencyContext(context.Background(), incident, &store.TeamConfig{}, deps, incident.FiredAt.Add(-30*time.Minute), result)
+
+	if len(result.Logs) != 1 || result.Logs[0].Message != "primary error" {
+		t.Fatalf("primary log should be unchanged, got %+v", result.Logs)
+	}
+}
+
+func TestApplyDependencyContext_SSRFBlockedPerDep(t *testing.T) {
+	internalEndpoint := "http://169.254.169.254/latest/meta-data"
+	cfg := &store.TeamConfig{LokiEndpoint: &internalEndpoint}
+	teamID := uuid.New()
+	incident := makeDepIncident(teamID)
+	deps := []*store.ServiceDependency{
+		{ID: uuid.New(), TeamID: teamID, Service: "api", DependsOn: "metadata-service"},
+	}
+
+	result := &correlator.Context{}
+	// Must not panic and must not collect from the blocked endpoint.
+	applyDependencyContext(context.Background(), incident, cfg, deps, incident.FiredAt.Add(-30*time.Minute), result)
+
+	if len(result.Logs) != 0 {
+		t.Fatal("expected no logs from SSRF-blocked endpoint")
+	}
+}
+
+func TestApplyDependencyContext_MultipleDepsIteratedWithoutPanic(t *testing.T) {
+	// Two deps, no connectors — verifies the loop runs for all deps without panic.
+	teamID := uuid.New()
+	incident := makeDepIncident(teamID)
+	deps := []*store.ServiceDependency{
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "redis-cache"},
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "payments-db"},
+	}
+
+	result := &correlator.Context{}
+	// Should complete without panic even though no connectors produce data.
+	applyDependencyContext(context.Background(), incident, &store.TeamConfig{}, deps, incident.FiredAt.Add(-30*time.Minute), result)
+}
+
+func TestApplyDependencyContext_SSRFBlockedOnFirstDepDoesNotPreventSecond(t *testing.T) {
+	// First dep: SSRF-blocked endpoint.
+	// Second dep: also blocked but verifies we reach it (no early exit on first failure).
+	internalEndpoint := "http://169.254.169.254/latest/meta-data"
+	cfg := &store.TeamConfig{LokiEndpoint: &internalEndpoint}
+	teamID := uuid.New()
+	incident := makeDepIncident(teamID)
+
+	// Use a counter to confirm both deps are processed. We observe this indirectly:
+	// if the loop exits early, a panic or incomplete iteration would show up.
+	// Both are SSRF-blocked so neither produces logs — but the loop must not exit after first.
+	deps := []*store.ServiceDependency{
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "redis-cache"},
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "payments-db"},
+	}
+
+	result := &correlator.Context{}
+	applyDependencyContext(context.Background(), incident, cfg, deps, incident.FiredAt.Add(-30*time.Minute), result)
+	// Both blocked — but function must complete (not panic or short-circuit unexpectedly).
+	if len(result.Logs) != 0 {
+		t.Fatalf("expected no logs from SSRF-blocked endpoints, got %d", len(result.Logs))
+	}
+}
+
+func TestApplyDependencyContext_LabelUsedInLogging(t *testing.T) {
+	// Verify label field is handled without panic when set and when nil.
+	teamID := uuid.New()
+	incident := makeDepIncident(teamID)
+	label := "shared Redis"
+	deps := []*store.ServiceDependency{
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "redis-cache", Label: &label},
+		{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "payments-db", Label: nil},
+	}
+
+	result := &correlator.Context{}
+	// No connectors — just verify nil/non-nil label is handled without panic.
+	applyDependencyContext(context.Background(), incident, &store.TeamConfig{}, deps, incident.FiredAt.Add(-30*time.Minute), result)
+}

--- a/cmd/worker/service_dependencies_test.go
+++ b/cmd/worker/service_dependencies_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -131,4 +132,111 @@ func TestApplyDependencyContext_LabelUsedInLogging(t *testing.T) {
 	result := &correlator.Context{}
 	// No connectors — just verify nil/non-nil label is handled without panic.
 	applyDependencyContext(context.Background(), incident, &store.TeamConfig{}, deps, incident.FiredAt.Add(-30*time.Minute), result)
+}
+
+// ── collectDepViaMCP tests ────────────────────────────────────────────────────
+
+// mockMCPCollector is a test double for grafanaMCPCollector.
+type mockMCPCollector struct {
+	logs        []collector.LogLine
+	logsErr     error
+	metrics     []collector.MetricPoint
+	metricsErr  error
+	calledFor   []string // service names passed to FetchErrorLogs
+}
+
+func (m *mockMCPCollector) FetchErrorLogs(_ context.Context, service string, _, _ time.Time, _ int) ([]collector.LogLine, error) {
+	m.calledFor = append(m.calledFor, service)
+	return m.logs, m.logsErr
+}
+
+func (m *mockMCPCollector) FetchErrorRate(_ context.Context, _ string, _ time.Duration) ([]collector.MetricPoint, error) {
+	return m.metrics, m.metricsErr
+}
+
+func TestCollectDepViaMCP_SuccessAppendsData(t *testing.T) {
+	logLine := collector.LogLine{Timestamp: time.Now().UTC(), Message: "redis timeout"}
+	metricPt := collector.MetricPoint{Timestamp: time.Now().UTC(), Value: 0.5}
+	mc := &mockMCPCollector{logs: []collector.LogLine{logLine}, metrics: []collector.MetricPoint{metricPt}}
+
+	teamID := uuid.New()
+	dep := &store.ServiceDependency{ID: uuid.New(), TeamID: teamID, Service: "checkout-api", DependsOn: "redis-cache"}
+	result := &correlator.Context{}
+	since := time.Now().Add(-30 * time.Minute)
+
+	logsOK, metricsOK := collectDepViaMCP(context.Background(), mc, dep, since, time.Now(), result)
+
+	if !logsOK || !metricsOK {
+		t.Fatalf("expected both OK, got logsOK=%v metricsOK=%v", logsOK, metricsOK)
+	}
+	if len(result.Logs) != 1 || result.Logs[0].Message != "redis timeout" {
+		t.Errorf("expected log appended, got %+v", result.Logs)
+	}
+	if len(result.Metrics) != 1 {
+		t.Errorf("expected metric appended, got %+v", result.Metrics)
+	}
+	if len(mc.calledFor) != 1 || mc.calledFor[0] != "redis-cache" {
+		t.Errorf("expected FetchErrorLogs called with dep.DependsOn, got %v", mc.calledFor)
+	}
+}
+
+func TestCollectDepViaMCP_LogsErrorReturnsFalseForLogs(t *testing.T) {
+	mc := &mockMCPCollector{logsErr: errors.New("mcp unavailable")}
+
+	teamID := uuid.New()
+	dep := &store.ServiceDependency{ID: uuid.New(), TeamID: teamID, Service: "api", DependsOn: "postgres"}
+	result := &correlator.Context{}
+	since := time.Now().Add(-30 * time.Minute)
+
+	logsOK, metricsOK := collectDepViaMCP(context.Background(), mc, dep, since, time.Now(), result)
+
+	if logsOK {
+		t.Error("expected logsOK=false when FetchErrorLogs returns error")
+	}
+	// Metrics call does not fail — metricsOK should be true.
+	if !metricsOK {
+		t.Error("expected metricsOK=true when FetchErrorRate succeeds")
+	}
+	if len(result.Logs) != 0 {
+		t.Errorf("expected no logs on error, got %d", len(result.Logs))
+	}
+}
+
+func TestCollectDepViaMCP_BothErrorsReturnFalse(t *testing.T) {
+	mc := &mockMCPCollector{
+		logsErr:    errors.New("timeout"),
+		metricsErr: errors.New("timeout"),
+	}
+
+	teamID := uuid.New()
+	dep := &store.ServiceDependency{ID: uuid.New(), TeamID: teamID, Service: "api", DependsOn: "postgres"}
+	result := &correlator.Context{}
+
+	logsOK, metricsOK := collectDepViaMCP(context.Background(), mc, dep, time.Now().Add(-30*time.Minute), time.Now(), result)
+
+	if logsOK || metricsOK {
+		t.Errorf("expected both false on error, got logsOK=%v metricsOK=%v", logsOK, metricsOK)
+	}
+	if len(result.Logs) != 0 || len(result.Metrics) != 0 {
+		t.Error("expected no data appended on error")
+	}
+}
+
+func TestCollectDepViaMCP_EmptySuccessDoesNotAppend(t *testing.T) {
+	// MCP returns no error but no data — both OK flags should be true so the dep
+	// is not double-collected via direct Loki/Prometheus.
+	mc := &mockMCPCollector{logs: nil, metrics: nil}
+
+	teamID := uuid.New()
+	dep := &store.ServiceDependency{ID: uuid.New(), TeamID: teamID, Service: "api", DependsOn: "redis"}
+	result := &correlator.Context{}
+
+	logsOK, metricsOK := collectDepViaMCP(context.Background(), mc, dep, time.Now().Add(-30*time.Minute), time.Now(), result)
+
+	if !logsOK || !metricsOK {
+		t.Errorf("expected both true for empty success, got logsOK=%v metricsOK=%v", logsOK, metricsOK)
+	}
+	if len(result.Logs) != 0 || len(result.Metrics) != 0 {
+		t.Error("expected result unchanged when MCP returns empty data")
+	}
 }

--- a/internal/oncall/schedule_test.go
+++ b/internal/oncall/schedule_test.go
@@ -61,6 +61,15 @@ func (m *mockConfigStore) GetTeamGraphConfig(_ context.Context, _ uuid.UUID) (*s
 func (m *mockConfigStore) UpsertTeamGraphConfig(_ context.Context, _ *store.TeamGraphConfig) error {
 	return nil
 }
+func (m *mockConfigStore) ListServiceDependencies(_ context.Context, _ uuid.UUID, _ string) ([]*store.ServiceDependency, error) {
+	return nil, nil
+}
+func (m *mockConfigStore) CreateServiceDependency(_ context.Context, _ *store.ServiceDependency) (*store.ServiceDependency, error) {
+	return nil, nil
+}
+func (m *mockConfigStore) DeleteServiceDependency(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	return nil
+}
 
 // Unused interface methods — return zero values.
 func (m *mockConfigStore) GetTeam(_ context.Context, _ uuid.UUID) (*store.Team, error) {

--- a/internal/store/config_store.go
+++ b/internal/store/config_store.go
@@ -65,6 +65,11 @@ type ConfigStore interface {
 	GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*TeamGraphConfig, error)
 	UpsertTeamGraphConfig(ctx context.Context, cfg *TeamGraphConfig) error
 
+	// Service dependencies
+	ListServiceDependencies(ctx context.Context, teamID uuid.UUID, service string) ([]*ServiceDependency, error)
+	CreateServiceDependency(ctx context.Context, d *ServiceDependency) (*ServiceDependency, error)
+	DeleteServiceDependency(ctx context.Context, teamID uuid.UUID, id uuid.UUID) error
+
 	// User notification rules
 	ListUserNotificationRules(ctx context.Context, userID uuid.UUID, userSource string) ([]*UserNotificationRule, error)
 	GetUserNotificationRules(ctx context.Context, userID uuid.UUID, userSource, eventType string) ([]*UserNotificationRule, error)

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -104,6 +104,18 @@ type TeamGraphConfig struct {
 	UpdatedAt          time.Time `json:"updated_at"`
 }
 
+// ServiceDependency declares that a service depends on another service.
+// When an alert fires for Service, the collector also pulls context for DependsOn
+// using the team's existing configured connectors.
+type ServiceDependency struct {
+	ID        uuid.UUID `json:"id"`
+	TeamID    uuid.UUID `json:"team_id"`
+	Service   string    `json:"service"`    // alerting service name (matches service tag on alerts)
+	DependsOn string    `json:"depends_on"` // dependency service name
+	Label     *string   `json:"label,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // SSOIdentity is a provider-level identity (one per person, not per team)
 type SSOIdentity struct {
 	ID         uuid.UUID  `json:"id"`

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -356,6 +356,24 @@ CREATE TABLE IF NOT EXISTS team_graph_config (
 );
 
 -- ============================================================
+-- Service dependencies
+-- Teams declare which services a given service depends on.
+-- When an alert fires for a service, the collector also pulls
+-- logs and metrics for each declared dependency using the team's
+-- existing configured connectors.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS service_dependencies (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id      UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    service      TEXT NOT NULL,
+    depends_on   TEXT NOT NULL,
+    label        TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(team_id, service, depends_on)
+);
+CREATE INDEX IF NOT EXISTS idx_service_deps_team_service ON service_dependencies(team_id, service);
+
+-- ============================================================
 -- Platform-wide system configuration (superadmin only)
 -- Singleton row: always use id = 1.
 -- ============================================================

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -373,6 +373,26 @@ CREATE TABLE IF NOT EXISTS service_dependencies (
 );
 CREATE INDEX IF NOT EXISTS idx_service_deps_team_service ON service_dependencies(team_id, service);
 
+-- Idempotent constraint additions (ADD CONSTRAINT IF NOT EXISTS is not supported
+-- for CHECK constraints in PostgreSQL; use DO/EXCEPTION instead).
+DO $$ BEGIN
+    ALTER TABLE service_dependencies
+        ADD CONSTRAINT chk_service_deps_no_self_dep
+        CHECK (lower(btrim(service)) <> lower(btrim(depends_on)));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE service_dependencies
+        ADD CONSTRAINT chk_service_deps_service_nonempty
+        CHECK (btrim(service) <> '');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE service_dependencies
+        ADD CONSTRAINT chk_service_deps_depends_on_nonempty
+        CHECK (btrim(depends_on) <> '');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
 -- ============================================================
 -- Platform-wide system configuration (superadmin only)
 -- Singleton row: always use id = 1.

--- a/internal/store/service_dependencies.go
+++ b/internal/store/service_dependencies.go
@@ -1,0 +1,109 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ListServiceDependencies returns all declared dependencies for a team.
+// If service is non-empty, only dependencies for that service are returned.
+func (db *DB) ListServiceDependencies(ctx context.Context, teamID uuid.UUID, service string) ([]*ServiceDependency, error) {
+	var rows pgx.Rows
+	var err error
+	if service != "" {
+		rows, err = db.pool.Query(ctx, `
+			SELECT id, team_id, service, depends_on, label, created_at
+			FROM service_dependencies
+			WHERE team_id = $1 AND service = $2
+			ORDER BY created_at ASC
+		`, teamID, service)
+	} else {
+		rows, err = db.pool.Query(ctx, `
+			SELECT id, team_id, service, depends_on, label, created_at
+			FROM service_dependencies
+			WHERE team_id = $1
+			ORDER BY service ASC, created_at ASC
+		`, teamID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list service dependencies: %w", err)
+	}
+	defer rows.Close()
+
+	var deps []*ServiceDependency
+	for rows.Next() {
+		d := &ServiceDependency{}
+		if err := rows.Scan(&d.ID, &d.TeamID, &d.Service, &d.DependsOn, &d.Label, &d.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan service dependency: %w", err)
+		}
+		deps = append(deps, d)
+	}
+	return deps, rows.Err()
+}
+
+// CreateServiceDependency inserts a new service dependency.
+// Returns the created record. Returns an error if the (team_id, service, depends_on)
+// combination already exists.
+func (db *DB) CreateServiceDependency(ctx context.Context, d *ServiceDependency) (*ServiceDependency, error) {
+	if d == nil {
+		return nil, fmt.Errorf("service dependency is required")
+	}
+	if d.TeamID == uuid.Nil {
+		return nil, fmt.Errorf("team_id is required")
+	}
+	if strings.TrimSpace(d.Service) == "" {
+		return nil, fmt.Errorf("service is required")
+	}
+	if strings.TrimSpace(d.DependsOn) == "" {
+		return nil, fmt.Errorf("depends_on is required")
+	}
+	if strings.EqualFold(strings.TrimSpace(d.Service), strings.TrimSpace(d.DependsOn)) {
+		return nil, fmt.Errorf("service cannot depend on itself")
+	}
+
+	created := &ServiceDependency{}
+	err := db.pool.QueryRow(ctx, `
+		INSERT INTO service_dependencies (team_id, service, depends_on, label)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, team_id, service, depends_on, label, created_at
+	`, d.TeamID, strings.TrimSpace(d.Service), strings.TrimSpace(d.DependsOn), d.Label).
+		Scan(&created.ID, &created.TeamID, &created.Service, &created.DependsOn, &created.Label, &created.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create service dependency: %w", err)
+	}
+	return created, nil
+}
+
+// DeleteServiceDependency removes a service dependency by ID.
+// Returns an error if the record does not exist or belongs to a different team.
+func (db *DB) DeleteServiceDependency(ctx context.Context, teamID uuid.UUID, id uuid.UUID) error {
+	tag, err := db.pool.Exec(ctx, `
+		DELETE FROM service_dependencies
+		WHERE id = $1 AND team_id = $2
+	`, id, teamID)
+	if err != nil {
+		return fmt.Errorf("delete service dependency: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("service dependency not found")
+	}
+	return nil
+}

--- a/internal/store/store_extended_test.go
+++ b/internal/store/store_extended_test.go
@@ -1714,3 +1714,145 @@ func TestDB_SyncTeamAccess_WithGroupMapping(t *testing.T) {
 		}
 	}
 }
+
+// ── Service Dependencies ──────────────────────────────────────────────────────
+
+func TestDB_ServiceDependencies_CreateListDelete(t *testing.T) {
+	db := requireDB(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, unique("dep-team"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	t.Cleanup(func() { _ = db.DeleteTeam(ctx, team.ID) })
+
+	label := "shared Redis"
+	dep, err := db.CreateServiceDependency(ctx, &ServiceDependency{
+		TeamID:    team.ID,
+		Service:   "checkout-api",
+		DependsOn: "redis-cache",
+		Label:     &label,
+	})
+	if err != nil {
+		t.Fatalf("CreateServiceDependency: %v", err)
+	}
+	if dep.ID == (uuid.UUID{}) {
+		t.Fatal("expected non-zero ID")
+	}
+	if dep.Service != "checkout-api" || dep.DependsOn != "redis-cache" {
+		t.Fatalf("unexpected fields: %+v", dep)
+	}
+
+	// List all for team
+	all, err := db.ListServiceDependencies(ctx, team.ID, "")
+	if err != nil {
+		t.Fatalf("ListServiceDependencies all: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != dep.ID {
+		t.Fatalf("expected 1 dependency, got %d", len(all))
+	}
+
+	// List filtered by service
+	filtered, err := db.ListServiceDependencies(ctx, team.ID, "checkout-api")
+	if err != nil {
+		t.Fatalf("ListServiceDependencies filtered: %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 filtered dependency, got %d", len(filtered))
+	}
+
+	// List for unknown service returns empty
+	empty, err := db.ListServiceDependencies(ctx, team.ID, "unknown-service")
+	if err != nil {
+		t.Fatalf("ListServiceDependencies unknown: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 for unknown service, got %d", len(empty))
+	}
+
+	// Delete
+	if err := db.DeleteServiceDependency(ctx, team.ID, dep.ID); err != nil {
+		t.Fatalf("DeleteServiceDependency: %v", err)
+	}
+	after, _ := db.ListServiceDependencies(ctx, team.ID, "")
+	if len(after) != 0 {
+		t.Fatal("expected empty after delete")
+	}
+}
+
+func TestDB_ServiceDependencies_DuplicateRejected(t *testing.T) {
+	db := requireDB(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, unique("dep-dup-team"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	t.Cleanup(func() { _ = db.DeleteTeam(ctx, team.ID) })
+
+	d := &ServiceDependency{TeamID: team.ID, Service: "api", DependsOn: "redis"}
+	if _, err := db.CreateServiceDependency(ctx, d); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := db.CreateServiceDependency(ctx, d); err == nil {
+		t.Fatal("expected error on duplicate, got nil")
+	}
+}
+
+func TestDB_ServiceDependencies_SelfDependencyRejected(t *testing.T) {
+	db := requireDB(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, unique("dep-self-team"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	t.Cleanup(func() { _ = db.DeleteTeam(ctx, team.ID) })
+
+	_, err = db.CreateServiceDependency(ctx, &ServiceDependency{
+		TeamID:    team.ID,
+		Service:   "api",
+		DependsOn: "api",
+	})
+	if err == nil {
+		t.Fatal("expected error for self-dependency, got nil")
+	}
+}
+
+func TestDB_ServiceDependencies_CrossTeamDeleteBlocked(t *testing.T) {
+	db := requireDB(t)
+	ctx := context.Background()
+
+	teamA, err := db.CreateTeam(ctx, unique("dep-team-a"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam A: %v", err)
+	}
+	teamB, err := db.CreateTeam(ctx, unique("dep-team-b"), unique("secret"))
+	if err != nil {
+		t.Fatalf("CreateTeam B: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.DeleteTeam(ctx, teamA.ID)
+		_ = db.DeleteTeam(ctx, teamB.ID)
+	})
+
+	dep, err := db.CreateServiceDependency(ctx, &ServiceDependency{
+		TeamID:    teamA.ID,
+		Service:   "checkout-api",
+		DependsOn: "redis-cache",
+	})
+	if err != nil {
+		t.Fatalf("CreateServiceDependency: %v", err)
+	}
+
+	// Team B cannot delete team A's dependency
+	if err := db.DeleteServiceDependency(ctx, teamB.ID, dep.ID); err == nil {
+		t.Fatal("expected error when deleting another team's dependency, got nil")
+	}
+
+	// Team A can still delete its own
+	if err := db.DeleteServiceDependency(ctx, teamA.ID, dep.ID); err != nil {
+		t.Fatalf("DeleteServiceDependency by owner: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `service_dependencies` table (scoped by `team_id`, self-dep guard, `UNIQUE(team_id, service, depends_on)`)
- `store.ListServiceDependencies`, `CreateServiceDependency`, `DeleteServiceDependency` — all filter by `team_id`
- REST API under `/api/v1/teams/{teamId}/dependencies`:
  - `GET` — list all deps, optional `?service=` filter
  - `POST` — create a dependency (admin only)
  - `DELETE /{id}` — remove a dependency (admin only)
- Worker: `collectDependencyContext` loads deps from DB and calls `applyDependencyContext` (pure function)
- `applyDependencyContext` fetches Loki logs + Prometheus metrics for each dependency service, with SSRF validation per endpoint before any HTTP call
- `TODO(#29)`: when Grafana MCP (PR #51) merges, swap in `collectGrafanaMCPContext` inside the dep loop

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `TestApplyDependencyContext_*` (6 unit tests in `cmd/worker/`) — all pass
- [ ] `TestDB_ServiceDependencies_*` (4 integration tests in `internal/store/`) — all pass
- [ ] SSRF test: Loki endpoint set to `169.254.169.254` — blocked, no logs collected
- [ ] Cross-team delete: team B cannot delete team A's dependency (RowsAffected check)

Closes #27