### PR TITLE
feat(graph): expose similarity and subgraph REST endpoints

### DIFF
--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -896,4 +896,18 @@ func TestE2E_GraphTeamIsolationAndViewerPromoteForbidden(t *testing.T) {
 	if resp.Code != http.StatusForbidden {
 		t.Fatalf("cross-team delete: got %d want 403", resp.Code)
 	}
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/teams/%s/graph/config", env.kafkaTeam.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("cross-team graph config read: got %d want 403", resp.Code)
+	}
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/teams/%s/graph/config", env.kongTeam.ID), nil)
+	req.AddCookie(env.kongViewerCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("viewer graph config read: got %d want 200 body=%s", resp.Code, resp.Body.String())
+	}
 }

--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/redis/go-redis/v9"
 	"github.com/wachd/wachd/internal/auth"
+	"github.com/wachd/wachd/internal/graph"
 	"github.com/wachd/wachd/internal/license"
 	"github.com/wachd/wachd/internal/oncall"
 	"github.com/wachd/wachd/internal/queue"
@@ -145,6 +146,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		sessions:       sessions,
 		license:        lic,
 		enc:            enc,
+		graphStore:     graph.NewPostgresStore(db.Pool()),
 		webhookLimiter: newWebhookIPLimiter(),
 	}
 
@@ -172,6 +174,12 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	api.HandleFunc("/{teamId}/members", server.handleListMembers).Methods("GET")
 	api.HandleFunc("/{teamId}/config", server.handleGetTeamConfig).Methods("GET")
 	api.HandleFunc("/{teamId}/config", server.handleUpsertTeamConfig).Methods("PUT")
+	api.HandleFunc("/{teamId}/graph/config", server.handleGetGraphConfig).Methods("GET")
+	api.HandleFunc("/{teamId}/graph/config", server.handleUpsertGraphConfig).Methods("PUT")
+	api.HandleFunc("/{teamId}/graph/nodes/{nodeId}", server.handleDeleteGraphNode).Methods("DELETE")
+	api.HandleFunc("/{teamId}/incidents/{incidentId}/similar", server.handleGetSimilarIncidents).Methods("GET")
+	api.HandleFunc("/{teamId}/incidents/{incidentId}/graph", server.handleGetIncidentGraph).Methods("GET")
+	api.HandleFunc("/{teamId}/incidents/{incidentId}/promote", server.handlePromoteIncidentGraphNode).Methods("POST")
 	api.HandleFunc("/{teamId}/schedule/overrides", server.handleCreateOverride).Methods("POST")
 	api.HandleFunc("/{teamId}/members/{userId}", server.handleUpdateMember).Methods("PUT")
 
@@ -707,6 +715,7 @@ func TestE2E_Override_ViewerIsDenied(t *testing.T) {
 		t.Errorf("viewer create override: got %d, want 403", resp.Code)
 	}
 }
+
 // admin role — a responder must receive 403 on both GET and PUT.
 func TestE2E_Config_RequiresAdmin(t *testing.T) {
 	env := newE2EEnv(t)
@@ -792,5 +801,99 @@ func TestE2E_UpdateMember_UserMustBeTeamMember(t *testing.T) {
 	resp := env.do(req)
 	if resp.Code != http.StatusUnprocessableEntity {
 		t.Errorf("phone update for non-member: got %d, want 422", resp.Code)
+	}
+}
+
+func TestE2E_GraphSimilarAndDeleteNode(t *testing.T) {
+	env := newE2EEnv(t)
+	ctx := context.Background()
+	gs := graph.NewPostgresStore(env.db.Pool())
+
+	incA := &store.Incident{TeamID: env.kongTeam.ID, Title: "Checkout timeout", Severity: "critical", Status: "resolved", Source: "grafana", FiredAt: time.Now().UTC().Add(-2 * time.Hour)}
+	incB := &store.Incident{TeamID: env.kongTeam.ID, Title: "Checkout payment timeout", Severity: "critical", Status: "resolved", Source: "grafana", FiredAt: time.Now().UTC().Add(-90 * time.Minute)}
+	if err := env.db.CreateIncident(ctx, incA); err != nil {
+		t.Fatalf("CreateIncident A: %v", err)
+	}
+	if err := env.db.CreateIncident(ctx, incB); err != nil {
+		t.Fatalf("CreateIncident B: %v", err)
+	}
+
+	extA, extB := incA.ID.String(), incB.ID.String()
+	nodeA, err := gs.UpsertNode(ctx, env.kongTeam.ID, &graph.Node{Type: graph.NodeTypeIncident, Status: graph.NodeStatusPermanent, Label: incA.Title, ExternalID: &extA})
+	if err != nil {
+		t.Fatalf("UpsertNode A: %v", err)
+	}
+	_, err = gs.UpsertNode(ctx, env.kongTeam.ID, &graph.Node{Type: graph.NodeTypeIncident, Status: graph.NodeStatusPermanent, Label: incB.Title, ExternalID: &extB})
+	if err != nil {
+		t.Fatalf("UpsertNode B: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/teams/%s/incidents/%s/similar", env.kongTeam.ID, incA.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("similar status: got %d want 200 body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Data []map[string]any `json:"data"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Data) == 0 {
+		t.Fatal("expected similarity results")
+	}
+
+	req = httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/teams/%s/graph/nodes/%s", env.kongTeam.ID, nodeA.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("delete node status: got %d want 200 body=%s", resp.Code, resp.Body.String())
+	}
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/teams/%s/incidents/%s/similar", env.kongTeam.ID, incA.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("similar after delete status: got %d want 200", resp.Code)
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Data) != 0 {
+		t.Fatalf("expected no similarity results after delete, got %+v", body.Data)
+	}
+}
+
+func TestE2E_GraphTeamIsolationAndViewerPromoteForbidden(t *testing.T) {
+	env := newE2EEnv(t)
+	ctx := context.Background()
+	gs := graph.NewPostgresStore(env.db.Pool())
+
+	inc := &store.Incident{TeamID: env.kafkaTeam.ID, Title: "Kafka timeout", Severity: "critical", Status: "resolved", Source: "grafana", FiredAt: time.Now().UTC()}
+	if err := env.db.CreateIncident(ctx, inc); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+	ext := inc.ID.String()
+	node, err := gs.UpsertNode(ctx, env.kafkaTeam.ID, &graph.Node{Type: graph.NodeTypeIncident, Status: graph.NodeStatusPending, Label: inc.Title, ExternalID: &ext})
+	if err != nil {
+		t.Fatalf("UpsertNode: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/teams/%s/incidents/%s/similar", env.kafkaTeam.ID, inc.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp := env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("cross-team similar: got %d want 403", resp.Code)
+	}
+
+	req = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/teams/%s/incidents/%s/promote", env.kafkaTeam.ID, inc.ID), nil)
+	req.AddCookie(env.kongViewerCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("viewer promote: got %d want 403", resp.Code)
+	}
+
+	req = httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/teams/%s/graph/nodes/%s", env.kafkaTeam.ID, node.ID), nil)
+	req.AddCookie(env.kongCookie)
+	resp = env.do(req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("cross-team delete: got %d want 403", resp.Code)
 	}
 }

--- a/cmd/server/graph_handlers_test.go
+++ b/cmd/server/graph_handlers_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func requireServerDB(t *testing.T) *store.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://wachd:wachd_dev_password@localhost:5432/wachd?sslmode=disable"
+	}
+	db, err := store.NewDB(dsn)
+	if err != nil {
+		t.Skipf("skip: cannot connect to test DB (%v)", err)
+	}
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestHandleGetSimilarIncidents_NoGraphNodesReturnsEmptyArray(t *testing.T) {
+	db := requireServerDB(t)
+	ctx := context.Background()
+	team, err := db.CreateTeam(ctx, "graph-unit-"+uuid.NewString()[:8], "secret-"+uuid.NewString()[:8])
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	t.Cleanup(func() { _ = db.DeleteTeam(ctx, team.ID) })
+	incident := &store.Incident{TeamID: team.ID, Title: "Payment timeout", Severity: "critical", Status: "resolved", Source: "grafana", FiredAt: time.Now().UTC()}
+	if err := db.CreateIncident(ctx, incident); err != nil {
+		t.Fatalf("CreateIncident: %v", err)
+	}
+
+	t.Setenv("AUTH_DISABLED", "true")
+	server := &Server{cfg: db, db: db, graphStore: graph.NewPostgresStore(db.Pool())}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = mux.SetURLVars(req, map[string]string{"teamId": team.ID.String(), "incidentId": incident.ID.String()})
+	w := httptest.NewRecorder()
+	server.handleGetSimilarIncidents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data  []map[string]interface{} `json:"data"`
+		Error interface{}              `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data) != 0 {
+		t.Fatalf("expected empty data array, got %+v", resp.Data)
+	}
+}
+
+func TestHandleGetSimilarIncidents_InvalidTeamID(t *testing.T) {
+	server := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = mux.SetURLVars(req, map[string]string{"teamId": "bad", "incidentId": uuid.NewString()})
+	w := httptest.NewRecorder()
+	server.handleGetSimilarIncidents(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteGraphNode_InvalidNodeID(t *testing.T) {
+	server := &Server{}
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+	req = mux.SetURLVars(req, map[string]string{"teamId": uuid.NewString(), "nodeId": "bad"})
+	w := httptest.NewRecorder()
+	server.handleDeleteGraphNode(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertGraphConfig_InvalidScore(t *testing.T) {
+	t.Setenv("AUTH_DISABLED", "true")
+	server := &Server{}
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(`{"enabled":true,"min_similarity_score":1.5}`))
+	req = mux.SetURLVars(req, map[string]string{"teamId": uuid.NewString()})
+	w := httptest.NewRecorder()
+	server.handleUpsertGraphConfig(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/redis/go-redis/v9"
 	"github.com/wachd/wachd/internal/auth"
+	"github.com/wachd/wachd/internal/graph"
 	"github.com/wachd/wachd/internal/license"
 	"github.com/wachd/wachd/internal/notify"
 	"github.com/wachd/wachd/internal/oncall"
@@ -57,6 +58,7 @@ type Server struct {
 	sessions          *auth.SessionStore
 	license           *license.License
 	enc               *auth.Encryptor
+	graphStore        graph.Store
 	port              string
 	webhookLimiter    *webhookIPLimiter
 	trustedProxyCIDRs []netip.Prefix
@@ -415,6 +417,7 @@ func main() {
 		sessions:          sessions,
 		license:           lic,
 		enc:               enc,
+		graphStore:        graph.NewPostgresStore(db.Pool()),
 		port:              port,
 		webhookLimiter:    newWebhookIPLimiter(),
 		trustedProxyCIDRs: trustedProxyCIDRs,
@@ -593,9 +596,15 @@ func main() {
 	apiRouter.HandleFunc("/{teamId}/members/{userId}", server.handleUpdateMember).Methods("PUT")
 	apiRouter.HandleFunc("/{teamId}/config", server.handleGetTeamConfig).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/config", server.handleUpsertTeamConfig).Methods("PUT")
+	apiRouter.HandleFunc("/{teamId}/graph/config", server.handleGetGraphConfig).Methods("GET")
+	apiRouter.HandleFunc("/{teamId}/graph/config", server.handleUpsertGraphConfig).Methods("PUT")
+	apiRouter.HandleFunc("/{teamId}/graph/nodes/{nodeId}", server.handleDeleteGraphNode).Methods("DELETE")
 	apiRouter.HandleFunc("/{teamId}/config/test-notification", server.handleTestNotification).Methods("POST")
 	apiRouter.HandleFunc("/{teamId}/escalation", server.handleGetEscalationPolicy).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/escalation", server.handleUpsertEscalationPolicy).Methods("PUT")
+	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/similar", server.handleGetSimilarIncidents).Methods("GET")
+	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/graph", server.handleGetIncidentGraph).Methods("GET")
+	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/promote", server.handlePromoteIncidentGraphNode).Methods("POST")
 
 	// Wrap router with CORS middleware
 	handler := corsMiddleware(router)
@@ -1806,6 +1815,339 @@ func (s *Server) handleUpsertEscalationPolicy(w http.ResponseWriter, r *http.Req
 		Config:    input.Config,
 		UpdatedAt: policy.UpdatedAt,
 	})
+}
+
+type graphEnvelope struct {
+	Data  interface{} `json:"data"`
+	Error interface{} `json:"error"`
+}
+
+type similarIncidentResponse struct {
+	IncidentID string     `json:"incident_id"`
+	Title      string     `json:"title"`
+	Score      float64    `json:"score"`
+	Reason     string     `json:"reason"`
+	OccurredAt *time.Time `json:"occurred_at,omitempty"`
+	Resolution string     `json:"resolution,omitempty"`
+}
+
+type graphConfigPayload struct {
+	Enabled            bool    `json:"enabled"`
+	MinSimilarityScore float64 `json:"min_similarity_score"`
+}
+
+func writeDataEnvelope(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(graphEnvelope{Data: data, Error: nil})
+}
+
+func (s *Server) graphStoreForTeam(ctx context.Context, teamID uuid.UUID) graph.Store {
+	cfg, err := s.cfg.GetTeamGraphConfig(ctx, teamID)
+	if err == nil && cfg != nil {
+		if s.db != nil {
+			return graph.NewPostgresStore(s.db.Pool()).WithMinimumSimilarityScore(cfg.MinSimilarityScore)
+		}
+	}
+	if s.graphStore != nil {
+		return s.graphStore
+	}
+	if s.db != nil {
+		return graph.NewPostgresStore(s.db.Pool())
+	}
+	return nil
+}
+
+func (s *Server) handleGetSimilarIncidents(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	incidentID, err := uuid.Parse(vars["incidentId"])
+	if err != nil {
+		http.Error(w, "invalid incident ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAccess(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	incident, err := s.db.GetIncident(r.Context(), teamID, incidentID)
+	if err != nil {
+		http.Error(w, "failed to load incident", http.StatusInternalServerError)
+		return
+	}
+	if incident == nil {
+		http.Error(w, "incident not found", http.StatusNotFound)
+		return
+	}
+	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	if err != nil {
+		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
+		return
+	}
+	if node == nil {
+		writeDataEnvelope(w, http.StatusOK, []similarIncidentResponse{})
+		return
+	}
+	gs := s.graphStoreForTeam(r.Context(), teamID)
+	if gs == nil {
+		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
+		return
+	}
+	matches, err := gs.FindSimilar(r.Context(), teamID, node.ID, 10)
+	if err != nil {
+		http.Error(w, "failed to find similar incidents", http.StatusInternalServerError)
+		return
+	}
+	resp := make([]similarIncidentResponse, 0, len(matches))
+	for _, match := range matches {
+		if match == nil || match.Node == nil || match.Node.ExternalID == nil {
+			continue
+		}
+		candidateID, err := uuid.Parse(*match.Node.ExternalID)
+		if err != nil {
+			continue
+		}
+		candidate, err := s.db.GetIncident(r.Context(), teamID, candidateID)
+		if err != nil || candidate == nil {
+			continue
+		}
+		occurredAt := candidate.FiredAt
+		resp = append(resp, similarIncidentResponse{
+			IncidentID: candidate.ID.String(),
+			Title:      candidate.Title,
+			Score:      match.Score,
+			Reason:     match.Reason,
+			OccurredAt: &occurredAt,
+			Resolution: incidentResolution(candidate.Analysis),
+		})
+	}
+	writeDataEnvelope(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleGetIncidentGraph(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	incidentID, err := uuid.Parse(vars["incidentId"])
+	if err != nil {
+		http.Error(w, "invalid incident ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAccess(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	incident, err := s.db.GetIncident(r.Context(), teamID, incidentID)
+	if err != nil {
+		http.Error(w, "failed to load incident", http.StatusInternalServerError)
+		return
+	}
+	if incident == nil {
+		http.Error(w, "incident not found", http.StatusNotFound)
+		return
+	}
+	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	if err != nil {
+		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
+		return
+	}
+	if node == nil {
+		writeDataEnvelope(w, http.StatusOK, &graph.Graph{Nodes: []*graph.Node{}, Edges: []*graph.Edge{}})
+		return
+	}
+	gs := s.graphStoreForTeam(r.Context(), teamID)
+	if gs == nil {
+		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
+		return
+	}
+	subgraph, err := gs.GetSubgraph(r.Context(), teamID, node.ID, 2)
+	if err != nil {
+		http.Error(w, "failed to load graph", http.StatusInternalServerError)
+		return
+	}
+	writeDataEnvelope(w, http.StatusOK, subgraph)
+}
+
+func (s *Server) handlePromoteIncidentGraphNode(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	incidentID, err := uuid.Parse(vars["incidentId"])
+	if err != nil {
+		http.Error(w, "invalid incident ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	incident, err := s.db.GetIncident(r.Context(), teamID, incidentID)
+	if err != nil {
+		http.Error(w, "failed to load incident", http.StatusInternalServerError)
+		return
+	}
+	if incident == nil {
+		http.Error(w, "incident not found", http.StatusNotFound)
+		return
+	}
+	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	if err != nil {
+		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
+		return
+	}
+	if node == nil {
+		http.Error(w, "graph node not found", http.StatusNotFound)
+		return
+	}
+	gs := s.graphStoreForTeam(r.Context(), teamID)
+	if gs == nil {
+		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
+		return
+	}
+	if err := gs.PromoteNode(r.Context(), teamID, node.ID); err != nil {
+		if errors.Is(err, graph.ErrNodeNotFound) {
+			http.Error(w, "graph node not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to promote graph node", http.StatusInternalServerError)
+		return
+	}
+	writeDataEnvelope(w, http.StatusOK, map[string]string{"status": "promoted", "node_id": node.ID.String()})
+}
+
+func (s *Server) handleDeleteGraphNode(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	nodeID, err := uuid.Parse(vars["nodeId"])
+	if err != nil {
+		http.Error(w, "invalid node ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	gs := s.graphStoreForTeam(r.Context(), teamID)
+	if gs == nil {
+		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
+		return
+	}
+	if err := gs.DeleteNode(r.Context(), teamID, nodeID); err != nil {
+		if errors.Is(err, graph.ErrNodeNotFound) {
+			http.Error(w, "graph node not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to delete graph node", http.StatusInternalServerError)
+		return
+	}
+	writeDataEnvelope(w, http.StatusOK, map[string]string{"deleted": nodeID.String()})
+}
+
+func (s *Server) handleGetGraphConfig(w http.ResponseWriter, r *http.Request) {
+	teamID, err := uuid.Parse(mux.Vars(r)["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	cfg, err := s.cfg.GetTeamGraphConfig(r.Context(), teamID)
+	if err != nil {
+		http.Error(w, "failed to load graph config", http.StatusInternalServerError)
+		return
+	}
+	writeDataEnvelope(w, http.StatusOK, graphConfigPayload{Enabled: cfg.Enabled, MinSimilarityScore: cfg.MinSimilarityScore})
+}
+
+func (s *Server) handleUpsertGraphConfig(w http.ResponseWriter, r *http.Request) {
+	teamID, err := uuid.Parse(mux.Vars(r)["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAdmin(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+	var input graphConfigPayload
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if input.MinSimilarityScore < 0 || input.MinSimilarityScore > 1 {
+		http.Error(w, "min_similarity_score must be between 0.0 and 1.0", http.StatusBadRequest)
+		return
+	}
+	cfg := &store.TeamGraphConfig{TeamID: teamID, Enabled: input.Enabled, MinSimilarityScore: input.MinSimilarityScore}
+	if err := s.cfg.UpsertTeamGraphConfig(r.Context(), cfg); err != nil {
+		http.Error(w, "failed to save graph config", http.StatusInternalServerError)
+		return
+	}
+	writeDataEnvelope(w, http.StatusOK, graphConfigPayload{Enabled: cfg.Enabled, MinSimilarityScore: cfg.MinSimilarityScore})
+}
+
+func (s *Server) lookupIncidentGraphNode(ctx context.Context, teamID, incidentID uuid.UUID) (*graph.Node, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	var node graph.Node
+	var externalID *string
+	err := s.db.Pool().QueryRow(ctx, `
+		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
+		FROM graph_nodes
+		WHERE team_id = $1 AND type = 'incident' AND external_id = $2
+	`, teamID, incidentID.String()).Scan(
+		&node.ID,
+		&node.TeamID,
+		&node.Type,
+		&node.Status,
+		&node.Label,
+		&externalID,
+		&node.Properties,
+		&node.CreatedAt,
+		&node.UpdatedAt,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	node.ExternalID = externalID
+	return &node, nil
+}
+
+func incidentResolution(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var parsed struct {
+		SuggestedAction string `json:"suggested_action"`
+		Resolution      string `json:"resolution"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return ""
+	}
+	if parsed.Resolution != "" {
+		return parsed.Resolution
+	}
+	return parsed.SuggestedAction
 }
 
 // requireTeamAdmin returns true when the caller holds admin or superadmin on teamID.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1842,20 +1842,18 @@ func writeDataEnvelope(w http.ResponseWriter, status int, data interface{}) {
 	_ = json.NewEncoder(w).Encode(graphEnvelope{Data: data, Error: nil})
 }
 
-func (s *Server) graphStoreForTeam(ctx context.Context, teamID uuid.UUID) graph.Store {
+func (s *Server) graphStoreForTeam(ctx context.Context, teamID uuid.UUID) (graph.Store, error) {
 	cfg, err := s.cfg.GetTeamGraphConfig(ctx, teamID)
-	if err == nil && cfg != nil {
-		if s.db != nil {
-			return graph.NewPostgresStore(s.db.Pool()).WithMinimumSimilarityScore(cfg.MinSimilarityScore)
-		}
-	}
-	if s.graphStore != nil {
-		return s.graphStore
+	if err != nil {
+		return nil, err
 	}
 	if s.db != nil {
-		return graph.NewPostgresStore(s.db.Pool())
+		return graph.NewPostgresStore(s.db.Pool()).WithMinimumSimilarityScore(cfg.MinSimilarityScore), nil
 	}
-	return nil
+	if s.graphStore != nil {
+		return s.graphStore, nil
+	}
+	return nil, errors.New("graph store unavailable")
 }
 
 func (s *Server) handleGetSimilarIncidents(w http.ResponseWriter, r *http.Request) {
@@ -1883,18 +1881,18 @@ func (s *Server) handleGetSimilarIncidents(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "incident not found", http.StatusNotFound)
 		return
 	}
-	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	gs, err := s.graphStoreForTeam(r.Context(), teamID)
 	if err != nil {
+		http.Error(w, "failed to load graph config", http.StatusInternalServerError)
+		return
+	}
+	node, err := gs.FindNodeByExternalID(r.Context(), teamID, graph.NodeTypeIncident, incident.ID.String())
+	if err != nil {
+		if errors.Is(err, graph.ErrNodeNotFound) {
+			writeDataEnvelope(w, http.StatusOK, []similarIncidentResponse{})
+			return
+		}
 		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
-		return
-	}
-	if node == nil {
-		writeDataEnvelope(w, http.StatusOK, []similarIncidentResponse{})
-		return
-	}
-	gs := s.graphStoreForTeam(r.Context(), teamID)
-	if gs == nil {
-		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
 		return
 	}
 	matches, err := gs.FindSimilar(r.Context(), teamID, node.ID, 10)
@@ -1902,7 +1900,8 @@ func (s *Server) handleGetSimilarIncidents(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "failed to find similar incidents", http.StatusInternalServerError)
 		return
 	}
-	resp := make([]similarIncidentResponse, 0, len(matches))
+	incidentIDs := make([]uuid.UUID, 0, len(matches))
+	matchByIncidentID := make(map[uuid.UUID]*graph.SimilarNode, len(matches))
 	for _, match := range matches {
 		if match == nil || match.Node == nil || match.Node.ExternalID == nil {
 			continue
@@ -1911,8 +1910,19 @@ func (s *Server) handleGetSimilarIncidents(w http.ResponseWriter, r *http.Reques
 		if err != nil {
 			continue
 		}
-		candidate, err := s.db.GetIncident(r.Context(), teamID, candidateID)
-		if err != nil || candidate == nil {
+		incidentIDs = append(incidentIDs, candidateID)
+		matchByIncidentID[candidateID] = match
+	}
+	incidentsByID, err := s.getIncidentsByIDs(r.Context(), teamID, incidentIDs)
+	if err != nil {
+		http.Error(w, "failed to load similar incidents", http.StatusInternalServerError)
+		return
+	}
+	resp := make([]similarIncidentResponse, 0, len(matchByIncidentID))
+	for _, incidentID := range incidentIDs {
+		candidate := incidentsByID[incidentID]
+		match := matchByIncidentID[incidentID]
+		if candidate == nil || match == nil {
 			continue
 		}
 		occurredAt := candidate.FiredAt
@@ -1953,18 +1963,18 @@ func (s *Server) handleGetIncidentGraph(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "incident not found", http.StatusNotFound)
 		return
 	}
-	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	gs, err := s.graphStoreForTeam(r.Context(), teamID)
 	if err != nil {
+		http.Error(w, "failed to load graph config", http.StatusInternalServerError)
+		return
+	}
+	node, err := gs.FindNodeByExternalID(r.Context(), teamID, graph.NodeTypeIncident, incident.ID.String())
+	if err != nil {
+		if errors.Is(err, graph.ErrNodeNotFound) {
+			writeDataEnvelope(w, http.StatusOK, &graph.Graph{Nodes: []*graph.Node{}, Edges: []*graph.Edge{}})
+			return
+		}
 		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
-		return
-	}
-	if node == nil {
-		writeDataEnvelope(w, http.StatusOK, &graph.Graph{Nodes: []*graph.Node{}, Edges: []*graph.Edge{}})
-		return
-	}
-	gs := s.graphStoreForTeam(r.Context(), teamID)
-	if gs == nil {
-		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
 		return
 	}
 	subgraph, err := gs.GetSubgraph(r.Context(), teamID, node.ID, 2)
@@ -2000,18 +2010,18 @@ func (s *Server) handlePromoteIncidentGraphNode(w http.ResponseWriter, r *http.R
 		http.Error(w, "incident not found", http.StatusNotFound)
 		return
 	}
-	node, err := s.lookupIncidentGraphNode(r.Context(), teamID, incident.ID)
+	gs, err := s.graphStoreForTeam(r.Context(), teamID)
 	if err != nil {
+		http.Error(w, "failed to load graph config", http.StatusInternalServerError)
+		return
+	}
+	node, err := gs.FindNodeByExternalID(r.Context(), teamID, graph.NodeTypeIncident, incident.ID.String())
+	if err != nil {
+		if errors.Is(err, graph.ErrNodeNotFound) {
+			http.Error(w, "graph node not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, "failed to lookup graph node", http.StatusInternalServerError)
-		return
-	}
-	if node == nil {
-		http.Error(w, "graph node not found", http.StatusNotFound)
-		return
-	}
-	gs := s.graphStoreForTeam(r.Context(), teamID)
-	if gs == nil {
-		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
 		return
 	}
 	if err := gs.PromoteNode(r.Context(), teamID, node.ID); err != nil {
@@ -2041,9 +2051,9 @@ func (s *Server) handleDeleteGraphNode(w http.ResponseWriter, r *http.Request) {
 		writeForbidden(w)
 		return
 	}
-	gs := s.graphStoreForTeam(r.Context(), teamID)
-	if gs == nil {
-		http.Error(w, "graph store unavailable", http.StatusInternalServerError)
+	gs, err := s.graphStoreForTeam(r.Context(), teamID)
+	if err != nil {
+		http.Error(w, "failed to load graph config", http.StatusInternalServerError)
 		return
 	}
 	if err := gs.DeleteNode(r.Context(), teamID, nodeID); err != nil {
@@ -2063,7 +2073,7 @@ func (s *Server) handleGetGraphConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid team ID", http.StatusBadRequest)
 		return
 	}
-	if !s.requireTeamAdmin(r, teamID) {
+	if !s.requireTeamAccess(r, teamID) {
 		writeForbidden(w)
 		return
 	}
@@ -2102,37 +2112,6 @@ func (s *Server) handleUpsertGraphConfig(w http.ResponseWriter, r *http.Request)
 	writeDataEnvelope(w, http.StatusOK, graphConfigPayload{Enabled: cfg.Enabled, MinSimilarityScore: cfg.MinSimilarityScore})
 }
 
-func (s *Server) lookupIncidentGraphNode(ctx context.Context, teamID, incidentID uuid.UUID) (*graph.Node, error) {
-	if s.db == nil {
-		return nil, nil
-	}
-	var node graph.Node
-	var externalID *string
-	err := s.db.Pool().QueryRow(ctx, `
-		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
-		FROM graph_nodes
-		WHERE team_id = $1 AND type = 'incident' AND external_id = $2
-	`, teamID, incidentID.String()).Scan(
-		&node.ID,
-		&node.TeamID,
-		&node.Type,
-		&node.Status,
-		&node.Label,
-		&externalID,
-		&node.Properties,
-		&node.CreatedAt,
-		&node.UpdatedAt,
-	)
-	if err != nil {
-		if strings.Contains(err.Error(), "no rows") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	node.ExternalID = externalID
-	return &node, nil
-}
-
 func incidentResolution(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""
@@ -2148,6 +2127,59 @@ func incidentResolution(raw json.RawMessage) string {
 		return parsed.Resolution
 	}
 	return parsed.SuggestedAction
+}
+
+func (s *Server) getIncidentsByIDs(ctx context.Context, teamID uuid.UUID, ids []uuid.UUID) (map[uuid.UUID]*store.Incident, error) {
+	results := make(map[uuid.UUID]*store.Incident, len(ids))
+	if len(ids) == 0 || s.db == nil {
+		return results, nil
+	}
+
+	rows, err := s.db.Pool().Query(ctx, `
+		SELECT
+			id, team_id, title, message, severity, status, source,
+			alert_payload, context, analysis,
+			fired_at, acknowledged_at, resolved_at, snoozed_until,
+			escalation_step, created_at, updated_at, assigned_to
+		FROM incidents
+		WHERE team_id = $1 AND id = ANY($2)
+	`, teamID, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		incident := &store.Incident{}
+		if err := rows.Scan(
+			&incident.ID,
+			&incident.TeamID,
+			&incident.Title,
+			&incident.Message,
+			&incident.Severity,
+			&incident.Status,
+			&incident.Source,
+			&incident.AlertPayload,
+			&incident.Context,
+			&incident.Analysis,
+			&incident.FiredAt,
+			&incident.AcknowledgedAt,
+			&incident.ResolvedAt,
+			&incident.SnoozedUntil,
+			&incident.EscalationStep,
+			&incident.CreatedAt,
+			&incident.UpdatedAt,
+			&incident.AssignedTo,
+		); err != nil {
+			return nil, err
+		}
+		results[incident.ID] = incident
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 // requireTeamAdmin returns true when the caller holds admin or superadmin on teamID.

--- a/cmd/worker/graph_test.go
+++ b/cmd/worker/graph_test.go
@@ -65,6 +65,10 @@ func (m *mockGraphStore) FindSimilar(context.Context, uuid.UUID, uuid.UUID, int)
 	panic("unexpected call")
 }
 
+func (m *mockGraphStore) FindNodeByExternalID(context.Context, uuid.UUID, graph.NodeType, string) (*graph.Node, error) {
+	panic("unexpected call")
+}
+
 func (m *mockGraphStore) PromoteNode(_ context.Context, _ uuid.UUID, nodeID uuid.UUID) error {
 	m.promoteCalled = true
 	m.promoteNodeID = nodeID

--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -1,0 +1,64 @@
+# Graph API
+
+Incident graph endpoints are scoped per team under `/api/v1/teams/{teamId}`.
+
+## Similar incidents
+
+- `GET /incidents/{id}/similar`
+- Role: viewer and above
+- Response:
+
+```json
+{
+  "data": [
+    {
+      "incident_id": "uuid",
+      "title": "Payment timeout",
+      "score": 0.84,
+      "reason": "similar root cause; same service: checkout-api",
+      "occurred_at": "2026-03-12T03:14:00Z",
+      "resolution": "rolled back v2.3.1"
+    }
+  ],
+  "error": null
+}
+```
+
+## Incident subgraph
+
+- `GET /incidents/{id}/graph`
+- Role: viewer and above
+- Returns the root node plus connected nodes/edges.
+
+## Promote incident node
+
+- `POST /incidents/{id}/promote`
+- Role: admin only
+- Promotes the incident node to `permanent` so it participates in similarity and traversal.
+
+## Delete graph node
+
+- `DELETE /graph/nodes/{nodeId}`
+- Role: admin only
+- Deletes the node and any connected edges inside the same `team_id` boundary.
+
+## Graph config
+
+- `GET /graph/config`
+- `PUT /graph/config`
+- Role: admin only
+
+Payload:
+
+```json
+{
+  "enabled": true,
+  "min_similarity_score": 0.12
+}
+```
+
+Validation:
+
+- `teamId`, `incidentId`, and `nodeId` must be valid UUIDs
+- `min_similarity_score` must be between `0.0` and `1.0`
+- All responses use the standard `{"data": ..., "error": null}` envelope on success

--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -45,6 +45,7 @@ Incident graph endpoints are scoped per team under `/api/v1/teams/{teamId}`.
 ## Graph config
 
 - `GET /graph/config`
+- Role: viewer and above
 - `PUT /graph/config`
 - Role: admin only
 
@@ -61,4 +62,5 @@ Validation:
 
 - `teamId`, `incidentId`, and `nodeId` must be valid UUIDs
 - `min_similarity_score` must be between `0.0` and `1.0`
-- All responses use the standard `{"data": ..., "error": null}` envelope on success
+- All graph endpoint success responses use the standard `{"data": ..., "error": null}` envelope
+- `enabled=false` disables future graph write-back for the team, but previously written graph data remains readable

--- a/internal/graph/postgres_store.go
+++ b/internal/graph/postgres_store.go
@@ -52,6 +52,15 @@ func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
 	}
 }
 
+// WithMinimumSimilarityScore overrides the default similarity threshold used
+// by FindSimilar for this store instance.
+func (s *PostgresStore) WithMinimumSimilarityScore(score float64) *PostgresStore {
+	if score >= 0 && score <= 1 {
+		s.minSimilarityScore = score
+	}
+	return s
+}
+
 // UpsertNode creates or updates a graph node.
 //
 // If ExternalID is set, the tuple (team_id, type, external_id) is treated as the

--- a/internal/graph/postgres_store.go
+++ b/internal/graph/postgres_store.go
@@ -405,6 +405,38 @@ func (s *PostgresStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeI
 	return matches, nil
 }
 
+// FindNodeByExternalID looks up a node by (team_id, type, external_id).
+func (s *PostgresStore) FindNodeByExternalID(ctx context.Context, teamID uuid.UUID, nodeType NodeType, externalID string) (*Node, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if teamID == uuid.Nil {
+		return nil, errors.New("team id is required")
+	}
+	if nodeType == "" {
+		return nil, errors.New("node type is required")
+	}
+	if strings.TrimSpace(externalID) == "" {
+		return nil, errors.New("external id is required")
+	}
+
+	node, err := scanNode(s.pool.QueryRow(ctx, `
+		SELECT id, team_id, type, status, label, external_id, properties, created_at, updated_at
+		FROM graph_nodes
+		WHERE team_id = $1
+		  AND type = $2
+		  AND external_id = $3
+	`, teamID, nodeType, externalID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNodeNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find graph node by external id: %w", err)
+	}
+
+	return node, nil
+}
+
 // PromoteNode marks a node as permanent.
 //
 // Any connected edges are promoted only when both endpoint nodes are permanent.

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -152,6 +152,10 @@ type Store interface {
 	// prevent active-incident AI analysis from contaminating similarity results.
 	FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*SimilarNode, error)
 
+	// FindNodeByExternalID resolves a node by its stable external identity within
+	// a team boundary.
+	FindNodeByExternalID(ctx context.Context, teamID uuid.UUID, nodeType NodeType, externalID string) (*Node, error)
+
 	// PromoteNode flips a node from pending to permanent, making it visible to
 	// FindSimilar and GetSubgraph neighbour traversal. Call this when the
 	// incident is resolved.


### PR DESCRIPTION
fix#42

This exposes the incident knowledge graph over the team API so similarity, subgraph traversal, manual promotion, node deletion, and graph configuration can be consumed by notifications and the frontend.

What changed
- Added graph endpoints for similar incidents, incident subgraphs, node promotion, node deletion, and graph config.
- Enforced viewer/admin RBAC and team isolation on every graph endpoint.
- Added graph config handling using the existing `team_graph_config` store defaults and validation.
- Added unit tests, HTTP integration tests, and graph API docs.

Verification
- `GOFLAGS=-p=1 go test ./cmd/server ./internal/graph`
- `GOFLAGS=-p=1 go test -tags integration -run TestE2E_Graph ./cmd/server`