### PR TITLE
feat(worker): include similar incidents in notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,6 @@ LOKI_ENDPOINT=http://loki:3100
 # ── Logging ───────────────────────────────────────────────────────────────────
 LOG_LEVEL=debug
 ENVIRONMENT=development
+
+# Public web dashboard URL used in alert notification links.
+WACHD_DASHBOARD_URL=http://localhost:3000

--- a/cmd/worker/helper.go
+++ b/cmd/worker/helper.go
@@ -747,7 +747,7 @@ func (w *Worker) checkEscalationForIncident(ctx context.Context, incident *store
 	log.Printf("⬆ Escalating incident %s to step %d%s (%s): %s", incident.ID, nextStep, repeatLabel, nextLayer.LayerName, user.Name)
 	// Escalation re-notifications fire all immediate channels directly — user
 	// delay rules apply only to the initial contact, not escalation reminders.
-	w.fireAllChannels(ctx, incident, user, nil)
+	w.fireAllChannels(ctx, incident, user, nil, nil)
 }
 
 // resolveLayerMember returns the on-call member for a specific schedule at the

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -391,14 +391,16 @@ func (w *Worker) processAlertJob(ctx context.Context, job *queue.Job) error {
 		}
 	}
 
+	similarIncident := w.findSimilarIncidentForNotification(ctx, incident, sanitizedCtx, aiAnalysis)
+
 	// Notify on-call engineer via their personal notification rules (email/SMS/voice).
 	// Slack fires separately below — once per incident, team-level, not per-user.
 	if onCallUser != nil {
-		w.sendNotifications(ctx, incident, onCallUser, aiAnalysis)
+		w.sendNotifications(ctx, incident, onCallUser, aiAnalysis, similarIncident)
 	}
 
 	// Fire team Slack channel once — one post per incident, keeps the channel clean.
-	w.fireTeamSlack(ctx, incident, onCallUser, aiAnalysis)
+	w.fireTeamSlack(ctx, incident, onCallUser, aiAnalysis, similarIncident)
 
 	log.Printf("✓ Incident %s processed", incident.ID)
 	return nil
@@ -425,7 +427,7 @@ func (w *Worker) processResolvedIncidentJob(ctx context.Context, job *queue.Job)
 // If the user has notification rules configured, only those channels fire (with
 // optional delay). If no rules exist the function falls back to firing all
 // globally-configured channels immediately (preserving pre-rules behaviour).
-func (w *Worker) sendNotifications(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse) {
+func (w *Worker) sendNotifications(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *notify.SimilarIncident) {
 	rules, err := w.db.GetUserNotificationRules(ctx, onCallUser.ID, onCallUser.Source, "new_alert")
 	if err != nil {
 		log.Printf("warn: load notification rules for user %s: %v — falling back to all channels", onCallUser.ID, err)
@@ -433,7 +435,7 @@ func (w *Worker) sendNotifications(ctx context.Context, incident *store.Incident
 
 	if len(rules) == 0 {
 		// No rules configured — fire all available channels immediately (legacy behaviour).
-		w.fireAllChannels(ctx, incident, onCallUser, analysis)
+		w.fireAllChannels(ctx, incident, onCallUser, analysis, similar)
 		return
 	}
 
@@ -442,7 +444,7 @@ func (w *Worker) sendNotifications(ctx context.Context, incident *store.Incident
 			continue
 		}
 		if rule.DelayMinutes == 0 {
-			w.fireChannel(ctx, rule.Channel, incident, onCallUser, analysis)
+			w.fireChannel(ctx, rule.Channel, incident, onCallUser, analysis, similar)
 		} else {
 			p := &store.PendingNotification{
 				IncidentID:  incident.ID,
@@ -463,7 +465,7 @@ func (w *Worker) sendNotifications(ctx context.Context, incident *store.Incident
 
 // fireTeamSlack posts one notification to the team Slack channel.
 // Called once when the incident is first created — not on escalation steps.
-func (w *Worker) fireTeamSlack(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse) {
+func (w *Worker) fireTeamSlack(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *notify.SimilarIncident) {
 	slackNotifier := w.slackNotifier
 	if cfg, err := w.db.GetTeamConfig(ctx, incident.TeamID); err == nil && cfg != nil {
 		if cfg.SlackWebhookURL != nil && *cfg.SlackWebhookURL != "" {
@@ -477,7 +479,7 @@ func (w *Worker) fireTeamSlack(ctx context.Context, incident *store.Incident, on
 	if slackNotifier == nil {
 		return
 	}
-	if err := slackNotifier.SendIncidentAlert(ctx, incident, onCallUser, analysis); err != nil {
+	if err := slackNotifier.SendIncidentAlertWithSimilar(ctx, incident, onCallUser, analysis, similar); err != nil {
 		log.Printf("Slack notification failed: %v", err)
 	} else {
 		log.Printf("  ✓ Slack (team channel)")
@@ -487,9 +489,9 @@ func (w *Worker) fireTeamSlack(ctx context.Context, incident *store.Incident, on
 // fireAllChannels sends email/SMS/voice for a user — used as fallback when no
 // notification rules are configured, and for escalation re-notifications.
 // Slack is intentionally excluded: it fires once at incident creation only.
-func (w *Worker) fireAllChannels(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse) {
+func (w *Worker) fireAllChannels(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *notify.SimilarIncident) {
 	if w.emailNotifier != nil {
-		if err := w.emailNotifier.SendIncidentAlert(ctx, incident, onCallUser, analysis); err != nil {
+		if err := w.emailNotifier.SendIncidentAlertWithSimilar(ctx, incident, onCallUser, analysis, similar); err != nil {
 			log.Printf("Email notification failed: %v", err)
 		} else {
 			log.Printf("  ✓ Email")
@@ -497,7 +499,7 @@ func (w *Worker) fireAllChannels(ctx context.Context, incident *store.Incident, 
 	}
 
 	if w.smsNotifier != nil {
-		if err := w.smsNotifier.SendIncidentAlert(ctx, incident, onCallUser, analysis); err != nil {
+		if err := w.smsNotifier.SendIncidentAlertWithSimilar(ctx, incident, onCallUser, analysis, similar); err != nil {
 			log.Printf("SMS notification failed: %v", err)
 		} else {
 			log.Printf("  ✓ SMS")
@@ -515,11 +517,11 @@ func (w *Worker) fireAllChannels(ctx context.Context, incident *store.Incident, 
 
 // fireChannel sends a single notification channel for a user.
 // Slack is not handled here — it fires once at incident creation via fireTeamSlack.
-func (w *Worker) fireChannel(ctx context.Context, channel string, incident *store.Incident, user *store.TeamMember, analysis *ai.AnalysisResponse) {
+func (w *Worker) fireChannel(ctx context.Context, channel string, incident *store.Incident, user *store.TeamMember, analysis *ai.AnalysisResponse, similar *notify.SimilarIncident) {
 	switch channel {
 	case "email":
 		if w.emailNotifier != nil {
-			if err := w.emailNotifier.SendIncidentAlert(ctx, incident, user, analysis); err != nil {
+			if err := w.emailNotifier.SendIncidentAlertWithSimilar(ctx, incident, user, analysis, similar); err != nil {
 				log.Printf("Email notification failed: %v", err)
 			} else {
 				log.Printf("  ✓ Email")
@@ -527,7 +529,7 @@ func (w *Worker) fireChannel(ctx context.Context, channel string, incident *stor
 		}
 	case "sms":
 		if w.smsNotifier != nil {
-			if err := w.smsNotifier.SendIncidentAlert(ctx, incident, user, analysis); err != nil {
+			if err := w.smsNotifier.SendIncidentAlertWithSimilar(ctx, incident, user, analysis, similar); err != nil {
 				log.Printf("SMS notification failed: %v", err)
 			} else {
 				log.Printf("  ✓ SMS")
@@ -587,7 +589,7 @@ func (w *Worker) firePendingNotifications(ctx context.Context) {
 			continue
 		}
 		log.Printf("⏰ Firing delayed %s for incident %s (user: %s)", p.Channel, p.IncidentID, user.Name)
-		w.fireChannel(ctx, p.Channel, incident, user, nil) // no AI analysis for delayed sends
+		w.fireChannel(ctx, p.Channel, incident, user, nil, nil) // no AI analysis for delayed sends
 		_ = w.db.MarkPendingNotificationSent(ctx, p.ID)
 	}
 }

--- a/cmd/worker/similar_notification.go
+++ b/cmd/worker/similar_notification.go
@@ -66,6 +66,8 @@ func loadSimilarIncidentForNotification(ctx context.Context, lookup notification
 	if err != nil {
 		return nil, fmt.Errorf("load graph config: %w", err)
 	}
+	// Missing graph config means the team has not opted out, so the graph is
+	// enabled by default. Only an explicit enabled=false disables lookup.
 	if cfg != nil && !cfg.Enabled {
 		return nil, nil
 	}

--- a/cmd/worker/similar_notification.go
+++ b/cmd/worker/similar_notification.go
@@ -1,0 +1,203 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/notify"
+	"github.com/wachd/wachd/internal/store"
+)
+
+const (
+	similarIncidentNotificationThreshold = 0.50
+	similarIncidentNotificationLimit     = 1
+)
+
+type notificationLookupStore interface {
+	GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*store.TeamGraphConfig, error)
+	GetIncident(ctx context.Context, teamID uuid.UUID, id uuid.UUID) (*store.Incident, error)
+}
+
+func (w *Worker) findSimilarIncidentForNotification(ctx context.Context, incident *store.Incident, sanitizedCtx *correlator.Context, analysis *ai.AnalysisResponse) *notify.SimilarIncident {
+	if w == nil || w.db == nil || incident == nil {
+		return nil
+	}
+
+	similar, err := loadSimilarIncidentForNotification(ctx, w.db, w.graphStore, incident.TeamID, func() (*graph.Node, error) {
+		return w.buildResolvedIncidentNode(incident, sanitizedCtx, analysis)
+	}, dashboardBaseURL())
+	if err != nil {
+		log.Printf("warn: similar incident lookup skipped for incident %s: %v", incident.ID, err)
+		return nil
+	}
+
+	return similar
+}
+
+func loadSimilarIncidentForNotification(ctx context.Context, lookup notificationLookupStore, graphStore graph.Store, teamID uuid.UUID, buildNode func() (*graph.Node, error), dashboardBaseURL string) (*notify.SimilarIncident, error) {
+	if lookup == nil || graphStore == nil || buildNode == nil {
+		return nil, nil
+	}
+
+	cfg, err := lookup.GetTeamGraphConfig(ctx, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("load graph config: %w", err)
+	}
+	if cfg != nil && !cfg.Enabled {
+		return nil, nil
+	}
+
+	node, err := buildNode()
+	if err != nil {
+		return nil, fmt.Errorf("build active incident graph node: %w", err)
+	}
+	if node == nil {
+		return nil, nil
+	}
+
+	node.Status = graph.NodeStatusPending
+
+	node, err = graphStore.UpsertNode(ctx, teamID, node)
+	if err != nil {
+		return nil, fmt.Errorf("upsert active incident graph node: %w", err)
+	}
+
+	matches, err := graphStore.FindSimilar(ctx, teamID, node.ID, similarIncidentNotificationLimit)
+	if err != nil {
+		return nil, fmt.Errorf("find similar incidents: %w", err)
+	}
+	if len(matches) == 0 || matches[0] == nil || matches[0].Node == nil {
+		return nil, nil
+	}
+	if matches[0].Score < similarIncidentNotificationThreshold {
+		return nil, nil
+	}
+
+	return buildSimilarIncidentNotification(ctx, lookup, teamID, matches[0], dashboardBaseURL), nil
+}
+
+func buildSimilarIncidentNotification(ctx context.Context, lookup notificationLookupStore, teamID uuid.UUID, match *graph.SimilarNode, dashboardBaseURL string) *notify.SimilarIncident {
+	if match == nil || match.Node == nil {
+		return nil
+	}
+
+	node := match.Node
+
+	similar := &notify.SimilarIncident{
+		Title:      strings.TrimSpace(node.Label),
+		Score:      match.Score,
+		Resolution: extractGraphNodeResolution(node),
+	}
+
+	externalID := ""
+	if node.ExternalID != nil {
+		externalID = strings.TrimSpace(*node.ExternalID)
+	}
+
+	if externalID != "" {
+		similar.URL = dashboardIncidentURL(dashboardBaseURL, externalID)
+
+		if incidentID, err := uuid.Parse(externalID); err == nil && lookup != nil {
+			if incident, err := lookup.GetIncident(ctx, teamID, incidentID); err == nil && incident != nil {
+				similar.FiredAt = incident.FiredAt
+			}
+		}
+	}
+
+	if strings.TrimSpace(similar.Title) == "" {
+		similar.Title = "Untitled incident"
+	}
+
+	return similar
+}
+
+func extractGraphNodeResolution(node *graph.Node) string {
+	if node == nil || len(node.Properties) == 0 {
+		return ""
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(node.Properties, &props); err != nil {
+		return ""
+	}
+
+	for _, key := range []string{"resolution", "resolved_by", "resolvedBy", "fix", "suggested_action", "suggestedAction"} {
+		if value, ok := props[key]; ok {
+			if text := propertyText(value); text != "" {
+				return text
+			}
+		}
+	}
+
+	return ""
+}
+
+func propertyText(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := propertyText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	case map[string]any:
+		for _, key := range []string{"summary", "message", "value", "text"} {
+			if text := propertyText(typed[key]); text != "" {
+				return text
+			}
+		}
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func dashboardBaseURL() string {
+	for _, key := range []string{"WACHD_DASHBOARD_URL", "WACHD_WEB_URL", "PUBLIC_DASHBOARD_URL"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return strings.TrimRight(value, "/")
+		}
+	}
+
+	return "http://localhost:3000"
+}
+
+func dashboardIncidentURL(baseURL, incidentID string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	incidentID = strings.TrimSpace(incidentID)
+
+	if baseURL == "" || incidentID == "" {
+		return ""
+	}
+
+	return baseURL + "/incidents/" + url.PathEscape(incidentID)
+}

--- a/cmd/worker/similar_notification_integration_test.go
+++ b/cmd/worker/similar_notification_integration_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/collector"
+	"github.com/wachd/wachd/internal/correlator"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/queue"
+	"github.com/wachd/wachd/internal/sanitiser"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func TestWorkerSecondIncidentFindsResolvedGraphHistoryForNotification(t *testing.T) {
+	db := requireWorkerDB(t)
+
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, uniqueGraphName("similar-notification"), "secret")
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	defer func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id = $1", team.ID)
+	}()
+
+	worker := &Worker{
+		db:         db,
+		graphStore: graph.NewPostgresStore(db.Pool()),
+		sanitiser:  sanitiser.NewSanitiser(),
+	}
+
+	previous := createResolvedIncidentFixture(t, ctx, db, team.ID)
+	job := &queue.Job{
+		Type:       "incident_resolved",
+		IncidentID: previous.ID,
+		TeamID:     team.ID,
+	}
+	if err := worker.processResolvedIncidentJob(ctx, job); err != nil {
+		t.Fatalf("process resolved incident job: %v", err)
+	}
+
+	message := "Checkout is returning 500s after database pool exhaustion"
+	current := &store.Incident{
+		TeamID:   team.ID,
+		Title:    "Checkout database connection pool exhausted",
+		Message:  &message,
+		Severity: "critical",
+		Status:   "open",
+		FiredAt:  time.Now().UTC(),
+		AlertPayload: []byte(`{
+			"labels": {
+				"service": "checkout-api"
+			},
+			"annotations": {
+				"summary": "Checkout database pool exhausted"
+			}
+		}`),
+	}
+	if err := db.CreateIncident(ctx, current); err != nil {
+		t.Fatalf("create current incident: %v", err)
+	}
+
+	currentCtx := &correlator.Context{
+		Logs: []collector.LogLine{
+			{
+				Timestamp: time.Now().UTC(),
+				Message:   "dial tcp 10.0.0.12:5432 timeout while checkout-api handled request",
+				Labels: map[string]string{
+					"service": "checkout-api",
+				},
+			},
+		},
+		Metrics: []collector.MetricPoint{
+			{
+				Timestamp: time.Now().UTC(),
+				Value:     0.82,
+				Labels: map[string]string{
+					"__name__": "http_5xx_rate",
+					"service":  "checkout-api",
+				},
+			},
+		},
+	}
+	analysis := &ai.AnalysisResponse{
+		RootCause:       "database pool exhaustion",
+		SuggestedAction: "increase the checkout database pool size",
+		Confidence:      "high",
+	}
+
+	similar := worker.findSimilarIncidentForNotification(ctx, current, currentCtx, analysis)
+	if similar == nil {
+		t.Fatal("expected similar incident notification context")
+	}
+
+	if !strings.Contains(similar.Title, "Checkout timeout") {
+		t.Fatalf("expected similar title to reference previous incident, got %q", similar.Title)
+	}
+
+	for _, raw := range []string{"admin@example.com", "10.0.0.8"} {
+		if strings.Contains(similar.Title, raw) {
+			t.Fatalf("similar incident title leaked raw PII %q: %q", raw, similar.Title)
+		}
+	}
+
+	if similar.Score < similarIncidentNotificationThreshold {
+		t.Fatalf("expected score >= %.2f, got %.3f", similarIncidentNotificationThreshold, similar.Score)
+	}
+
+	if !strings.Contains(similar.Resolution, "rolled back") {
+		t.Fatalf("expected previous resolution from graph properties, got %q", similar.Resolution)
+	}
+
+	if !strings.Contains(similar.URL, previous.ID.String()) {
+		t.Fatalf("expected dashboard URL to include previous incident ID, got %q", similar.URL)
+	}
+}
+
+func TestWorkerSimilarIncidentNotificationNoGraphHistory(t *testing.T) {
+	db := requireWorkerDB(t)
+
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, uniqueGraphName("similar-notification-empty"), "secret")
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	defer func() {
+		_, _ = db.Pool().Exec(context.Background(), "DELETE FROM teams WHERE id = $1", team.ID)
+	}()
+
+	worker := &Worker{
+		db:         db,
+		graphStore: graph.NewPostgresStore(db.Pool()),
+		sanitiser:  sanitiser.NewSanitiser(),
+	}
+
+	message := "Checkout has a new alert with no history"
+	current := &store.Incident{
+		TeamID:       team.ID,
+		Title:        "Checkout first incident",
+		Message:      &message,
+		Severity:     "warning",
+		Status:       "open",
+		FiredAt:      time.Now().UTC(),
+		AlertPayload: []byte(`{"labels":{"service":"checkout-api"}}`),
+	}
+	if err := db.CreateIncident(ctx, current); err != nil {
+		t.Fatalf("create current incident: %v", err)
+	}
+
+	similar := worker.findSimilarIncidentForNotification(ctx, current, &correlator.Context{}, &ai.AnalysisResponse{
+		RootCause:       "new issue",
+		SuggestedAction: "investigate",
+		Confidence:      "medium",
+	})
+	if similar != nil {
+		t.Fatalf("expected no similar incident for empty graph history, got %+v", similar)
+	}
+}

--- a/cmd/worker/similar_notification_test.go
+++ b/cmd/worker/similar_notification_test.go
@@ -1,0 +1,288 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/wachd/wachd/internal/graph"
+	"github.com/wachd/wachd/internal/store"
+)
+
+func TestLoadSimilarIncidentForNotificationIncludesMatchAboveThreshold(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+	pastIncidentID := uuid.New()
+	pastExternalID := pastIncidentID.String()
+	pastFiredAt := time.Date(2026, 3, 12, 9, 30, 0, 0, time.UTC)
+
+	lookup := &similarNotificationLookup{
+		graphConfig: &store.TeamGraphConfig{
+			TeamID:  teamID,
+			Enabled: true,
+		},
+		incident: &store.Incident{
+			ID:      pastIncidentID,
+			TeamID:  teamID,
+			Title:   "Payment timeout",
+			FiredAt: pastFiredAt,
+		},
+	}
+
+	graphStore := &similarNotificationGraphStore{
+		matches: []*graph.SimilarNode{
+			{
+				Node: &graph.Node{
+					ID:         uuid.New(),
+					TeamID:     teamID,
+					Type:       graph.NodeTypeIncident,
+					Status:     graph.NodeStatusPermanent,
+					Label:      "Payment timeout",
+					ExternalID: &pastExternalID,
+					Properties: rawGraphProperties(t, map[string]any{
+						"resolution": "rolled back v2.3.1",
+					}),
+				},
+				Score:  0.84,
+				Reason: "similar root cause text",
+			},
+		},
+	}
+
+	similar, err := loadSimilarIncidentForNotification(ctx, lookup, graphStore, teamID, func() (*graph.Node, error) {
+		return &graph.Node{
+			ID:     uuid.New(),
+			TeamID: teamID,
+			Type:   graph.NodeTypeIncident,
+			Label:  "New payment timeout",
+		}, nil
+	}, "https://wachd.example.com")
+	if err != nil {
+		t.Fatalf("load similar incident: %v", err)
+	}
+
+	if similar == nil {
+		t.Fatal("expected similar incident")
+	}
+
+	if similar.Title != "Payment timeout" {
+		t.Fatalf("expected title from graph node, got %q", similar.Title)
+	}
+
+	if similar.Score != 0.84 {
+		t.Fatalf("expected score 0.84, got %.2f", similar.Score)
+	}
+
+	if similar.Resolution != "rolled back v2.3.1" {
+		t.Fatalf("expected previous resolution, got %q", similar.Resolution)
+	}
+
+	if !strings.Contains(similar.URL, pastIncidentID.String()) {
+		t.Fatalf("expected dashboard URL to contain incident ID, got %q", similar.URL)
+	}
+
+	if !similar.FiredAt.Equal(pastFiredAt) {
+		t.Fatalf("expected fired_at %s, got %s", pastFiredAt, similar.FiredAt)
+	}
+}
+
+func TestLoadSimilarIncidentForNotificationOmitsMatchBelowThreshold(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+
+	graphStore := &similarNotificationGraphStore{
+		matches: []*graph.SimilarNode{
+			{
+				Node: &graph.Node{
+					ID:     uuid.New(),
+					TeamID: teamID,
+					Type:   graph.NodeTypeIncident,
+					Label:  "Weak match",
+				},
+				Score: 0.49,
+			},
+		},
+	}
+
+	similar, err := loadSimilarIncidentForNotification(ctx, enabledGraphLookup(teamID), graphStore, teamID, func() (*graph.Node, error) {
+		return &graph.Node{
+			ID:     uuid.New(),
+			TeamID: teamID,
+			Type:   graph.NodeTypeIncident,
+			Label:  "New incident",
+		}, nil
+	}, "https://wachd.example.com")
+	if err != nil {
+		t.Fatalf("load similar incident: %v", err)
+	}
+
+	if similar != nil {
+		t.Fatalf("expected no similar incident below threshold, got %+v", similar)
+	}
+}
+
+func TestLoadSimilarIncidentForNotificationReturnsErrorWhenFindSimilarErrors(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+
+	graphStore := &similarNotificationGraphStore{
+		findErr: errors.New("similarity backend unavailable"),
+	}
+
+	similar, err := loadSimilarIncidentForNotification(ctx, enabledGraphLookup(teamID), graphStore, teamID, func() (*graph.Node, error) {
+		return &graph.Node{
+			ID:     uuid.New(),
+			TeamID: teamID,
+			Type:   graph.NodeTypeIncident,
+			Label:  "New incident",
+		}, nil
+	}, "https://wachd.example.com")
+
+	if similar != nil {
+		t.Fatalf("expected no similar incident when FindSimilar errors, got %+v", similar)
+	}
+
+	if err == nil {
+		t.Fatal("expected FindSimilar error to be returned to the worker for logging")
+	}
+}
+
+func TestLoadSimilarIncidentForNotificationOmitsWhenGraphDisabled(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+
+	lookup := &similarNotificationLookup{
+		graphConfig: &store.TeamGraphConfig{
+			TeamID:  teamID,
+			Enabled: false,
+		},
+	}
+	graphStore := &similarNotificationGraphStore{}
+
+	similar, err := loadSimilarIncidentForNotification(ctx, lookup, graphStore, teamID, func() (*graph.Node, error) {
+		t.Fatal("buildNode should not be called when graph is disabled")
+		return nil, nil
+	}, "https://wachd.example.com")
+	if err != nil {
+		t.Fatalf("load similar incident: %v", err)
+	}
+
+	if similar != nil {
+		t.Fatalf("expected no similar incident when graph is disabled, got %+v", similar)
+	}
+
+	if graphStore.upsertCalled {
+		t.Fatal("expected graph node not to be written when graph is disabled")
+	}
+}
+
+func enabledGraphLookup(teamID uuid.UUID) *similarNotificationLookup {
+	return &similarNotificationLookup{
+		graphConfig: &store.TeamGraphConfig{
+			TeamID:  teamID,
+			Enabled: true,
+		},
+	}
+}
+
+type similarNotificationLookup struct {
+	graphConfig *store.TeamGraphConfig
+	configErr   error
+	incident    *store.Incident
+	incidentErr error
+}
+
+func (s *similarNotificationLookup) GetTeamGraphConfig(ctx context.Context, teamID uuid.UUID) (*store.TeamGraphConfig, error) {
+	return s.graphConfig, s.configErr
+}
+
+func (s *similarNotificationLookup) GetIncident(ctx context.Context, teamID uuid.UUID, id uuid.UUID) (*store.Incident, error) {
+	if s.incidentErr != nil {
+		return nil, s.incidentErr
+	}
+
+	if s.incident != nil && s.incident.ID == id && s.incident.TeamID == teamID {
+		return s.incident, nil
+	}
+
+	return nil, nil
+}
+
+type similarNotificationGraphStore struct {
+	upsertCalled bool
+	upsertErr    error
+	findErr      error
+	matches      []*graph.SimilarNode
+}
+
+func (s *similarNotificationGraphStore) UpsertNode(ctx context.Context, teamID uuid.UUID, n *graph.Node) (*graph.Node, error) {
+	s.upsertCalled = true
+
+	if s.upsertErr != nil {
+		return nil, s.upsertErr
+	}
+
+	if n.ID == uuid.Nil {
+		n.ID = uuid.New()
+	}
+	n.TeamID = teamID
+
+	return n, nil
+}
+
+func (s *similarNotificationGraphStore) UpsertEdge(ctx context.Context, teamID uuid.UUID, e *graph.Edge) (*graph.Edge, error) {
+	panic("not used")
+}
+
+func (s *similarNotificationGraphStore) GetSubgraph(ctx context.Context, teamID uuid.UUID, rootNodeID uuid.UUID, depth int) (*graph.Graph, error) {
+	panic("not used")
+}
+
+func (s *similarNotificationGraphStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*graph.SimilarNode, error) {
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+
+	return s.matches, nil
+}
+
+func (s *similarNotificationGraphStore) FindNodeByExternalID(ctx context.Context, teamID uuid.UUID, nodeType graph.NodeType, externalID string) (*graph.Node, error) {
+	panic("not used")
+}
+
+func (s *similarNotificationGraphStore) PromoteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error {
+	panic("not used")
+}
+
+func (s *similarNotificationGraphStore) DeleteNode(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID) error {
+	panic("not used")
+}
+
+func rawGraphProperties(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal graph properties: %v", err)
+	}
+
+	return raw
+}

--- a/cmd/worker/similar_notification_test.go
+++ b/cmd/worker/similar_notification_test.go
@@ -165,6 +165,46 @@ func TestLoadSimilarIncidentForNotificationReturnsErrorWhenFindSimilarErrors(t *
 	}
 }
 
+func TestLoadSimilarIncidentForNotificationTreatsMissingGraphConfigAsEnabled(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+
+	lookup := &similarNotificationLookup{
+		graphConfig: nil,
+	}
+	graphStore := &similarNotificationGraphStore{}
+
+	buildCalled := false
+	similar, err := loadSimilarIncidentForNotification(ctx, lookup, graphStore, teamID, func() (*graph.Node, error) {
+		buildCalled = true
+		return &graph.Node{
+			ID:     uuid.New(),
+			TeamID: teamID,
+			Type:   graph.NodeTypeIncident,
+			Label:  "New incident",
+		}, nil
+	}, "https://wachd.example.com")
+	if err != nil {
+		t.Fatalf("load similar incident: %v", err)
+	}
+
+	if similar != nil {
+		t.Fatalf("expected no similar incident when graph has no matches, got %+v", similar)
+	}
+
+	if !buildCalled {
+		t.Fatal("expected active incident graph node to be built when config row is missing")
+	}
+
+	if !graphStore.upsertCalled {
+		t.Fatal("expected graph node to be written when config row is missing")
+	}
+
+	if !graphStore.findCalled {
+		t.Fatal("expected FindSimilar to run when config row is missing")
+	}
+}
+
 func TestLoadSimilarIncidentForNotificationOmitsWhenGraphDisabled(t *testing.T) {
 	ctx := context.Background()
 	teamID := uuid.New()
@@ -228,6 +268,7 @@ func (s *similarNotificationLookup) GetIncident(ctx context.Context, teamID uuid
 
 type similarNotificationGraphStore struct {
 	upsertCalled bool
+	findCalled   bool
 	upsertErr    error
 	findErr      error
 	matches      []*graph.SimilarNode
@@ -257,6 +298,8 @@ func (s *similarNotificationGraphStore) GetSubgraph(ctx context.Context, teamID 
 }
 
 func (s *similarNotificationGraphStore) FindSimilar(ctx context.Context, teamID uuid.UUID, nodeID uuid.UUID, limit int) ([]*graph.SimilarNode, error) {
+	s.findCalled = true
+
 	if s.findErr != nil {
 		return nil, s.findErr
 	}

--- a/internal/notify/similar_incident.go
+++ b/internal/notify/similar_incident.go
@@ -1,0 +1,335 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/smtp"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/wachd/wachd/internal/ai"
+	"github.com/wachd/wachd/internal/store"
+)
+
+const maxSMSIncidentAlertChars = 160
+
+// SimilarIncident is the small notification-safe representation of the best
+// historical incident match.
+type SimilarIncident struct {
+	Title      string
+	Score      float64
+	Resolution string
+	URL        string
+	FiredAt    time.Time
+}
+
+// SendIncidentAlertWithSimilar sends the normal Slack incident alert and, when
+// present, includes the most similar past incident.
+func (s *SlackNotifier) SendIncidentAlertWithSimilar(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *SimilarIncident) error {
+	text := fmt.Sprintf("*Alert:* %s", incident.Title)
+
+	onCallText := "Unassigned"
+	if onCallUser != nil {
+		onCallText = fmt.Sprintf("%s <%s>", onCallUser.Name, onCallUser.Email)
+	}
+
+	message := SlackMessage{
+		Channel: s.channel,
+		Text:    text,
+		Blocks: []Block{
+			{
+				Type: "section",
+				Text: &Text{
+					Type: "mrkdwn",
+					Text: text,
+				},
+			},
+			{
+				Type: "section",
+				Text: &Text{
+					Type: "mrkdwn",
+					Text: fmt.Sprintf(
+						"*Severity:* %s\n*Source:* %s\n*On-Call:* %s",
+						incident.Severity,
+						incident.Source,
+						onCallText,
+					),
+				},
+			},
+		},
+	}
+
+	if incident.Message != nil && *incident.Message != "" {
+		message.Blocks = append(message.Blocks, Block{
+			Type: "section",
+			Text: &Text{
+				Type: "mrkdwn",
+				Text: fmt.Sprintf("*Message:* %s", *incident.Message),
+			},
+		})
+	}
+
+	if analysis != nil {
+		analysisText := fmt.Sprintf(
+			"*Root Cause Analysis:*\n\n*Probable Cause:* %s\n\n*Suggested Action:* %s\n\n*Confidence:* %s",
+			analysis.RootCause,
+			analysis.SuggestedAction,
+			analysis.Confidence,
+		)
+
+		message.Blocks = append(message.Blocks, Block{
+			Type: "section",
+			Text: &Text{
+				Type: "mrkdwn",
+				Text: analysisText,
+			},
+		})
+	}
+
+	if similar != nil {
+		message.Blocks = append(message.Blocks, Block{
+			Type: "section",
+			Text: &Text{
+				Type: "mrkdwn",
+				Text: formatSimilarIncidentSlack(similar),
+			},
+		})
+	}
+
+	message.Blocks = append(message.Blocks, Block{
+		Type: "section",
+		Text: &Text{
+			Type: "mrkdwn",
+			Text: fmt.Sprintf(
+				"*Incident ID:* `%s`\n*Fired at:* %s",
+				incident.ID.String(),
+				incident.FiredAt.Format(time.RFC3339),
+			),
+		},
+	})
+
+	return s.sendMessage(ctx, message)
+}
+
+// SendIncidentAlertWithSimilar sends the normal email alert and, when present,
+// includes the most similar past incident.
+func (e *EmailNotifier) SendIncidentAlertWithSimilar(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *SimilarIncident) error {
+	if similar == nil {
+		return e.SendIncidentAlert(ctx, incident, onCallUser, analysis)
+	}
+
+	if e.smtpHost == "" {
+		return fmt.Errorf("SMTP server not configured")
+	}
+	if onCallUser == nil {
+		return fmt.Errorf("on-call user is required")
+	}
+
+	subject := fmt.Sprintf("[Wachd Alert] %s - %s", incident.Severity, incident.Title)
+	body := e.buildEmailBodyWithSimilar(incident, onCallUser, analysis, similar)
+
+	to := []string{onCallUser.Email}
+	message := e.formatEmailMessage(to, subject, body)
+
+	auth := smtp.PlainAuth("", e.username, e.password, e.smtpHost)
+	addr := fmt.Sprintf("%s:%s", e.smtpHost, e.smtpPort)
+
+	if err := smtp.SendMail(addr, auth, e.from, to, []byte(message)); err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	return nil
+}
+
+func (e *EmailNotifier) buildEmailBodyWithSimilar(incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *SimilarIncident) string {
+	body := e.buildEmailBody(incident, onCallUser, analysis)
+	if similar == nil {
+		return body
+	}
+
+	section := formatSimilarIncidentEmail(similar)
+
+	footer := "---\n"
+	if idx := strings.Index(body, footer); idx >= 0 {
+		return body[:idx] + section + "\n" + body[idx:]
+	}
+
+	return strings.TrimRight(body, "\n") + "\n\n" + section
+}
+
+// SendIncidentAlertWithSimilar sends the normal SMS alert and, when present,
+// appends one short similar-incident sentence capped to 160 characters.
+func (s *SMSNotifier) SendIncidentAlertWithSimilar(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *SimilarIncident) error {
+	if similar == nil {
+		return s.SendIncidentAlert(ctx, incident, onCallUser, analysis)
+	}
+
+	if onCallUser == nil || onCallUser.Phone == nil || *onCallUser.Phone == "" {
+		return nil
+	}
+
+	body := s.buildMessageWithSimilar(incident, analysis, similar)
+
+	apiURL := fmt.Sprintf("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", s.accountSid)
+
+	form := url.Values{}
+	form.Set("From", s.fromNumber)
+	form.Set("To", *onCallUser.Phone)
+	form.Set("Body", body)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("sms: create request: %w", err)
+	}
+
+	req.SetBasicAuth(s.accountSid, s.authToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := s.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sms: twilio request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("sms: twilio returned %d: %s", resp.StatusCode, string(b))
+	}
+
+	return nil
+}
+
+func (s *SMSNotifier) buildMessageWithSimilar(incident *store.Incident, analysis *ai.AnalysisResponse, similar *SimilarIncident) string {
+	base := s.buildMessage(incident, analysis)
+	if similar == nil {
+		return truncateRunes(base, maxSMSIncidentAlertChars)
+	}
+
+	title := strings.TrimSpace(similar.Title)
+	if title == "" {
+		title = "past incident"
+	}
+
+	suffix := fmt.Sprintf(" Similar: %s (%s).", truncateRunes(title, 34), formatSimilarityPercent(similar.Score))
+
+	if runeLen(base)+runeLen(suffix) <= maxSMSIncidentAlertChars {
+		return base + suffix
+	}
+
+	allowedBase := maxSMSIncidentAlertChars - runeLen(suffix)
+	if allowedBase <= 0 {
+		return truncateRunes(strings.TrimSpace(suffix), maxSMSIncidentAlertChars)
+	}
+
+	return truncateRunes(base, allowedBase) + suffix
+}
+
+func formatSimilarIncidentSlack(similar *SimilarIncident) string {
+	title := strings.TrimSpace(similar.Title)
+	if title == "" {
+		title = "Untitled incident"
+	}
+
+	text := fmt.Sprintf("*Similar past incident (%s):* %s", formatSimilarityPercent(similar.Score), title)
+
+	if !similar.FiredAt.IsZero() {
+		text += fmt.Sprintf(" - %s", similar.FiredAt.Format("Jan 2"))
+	}
+
+	if strings.TrimSpace(similar.Resolution) != "" {
+		text += fmt.Sprintf("\n*Previous resolution:* %s", strings.TrimSpace(similar.Resolution))
+	}
+
+	if strings.TrimSpace(similar.URL) != "" {
+		text += fmt.Sprintf("  ->  <%s|view>", strings.TrimSpace(similar.URL))
+	}
+
+	return text
+}
+
+func formatSimilarIncidentEmail(similar *SimilarIncident) string {
+	var b strings.Builder
+
+	title := strings.TrimSpace(similar.Title)
+	if title == "" {
+		title = "Untitled incident"
+	}
+
+	b.WriteString("Similar past incident\n")
+	b.WriteString("---------------------\n")
+	b.WriteString(fmt.Sprintf("Title: %s\n", title))
+	b.WriteString(fmt.Sprintf("Similarity: %s\n", formatSimilarityPercent(similar.Score)))
+
+	if !similar.FiredAt.IsZero() {
+		b.WriteString(fmt.Sprintf("Fired at: %s\n", similar.FiredAt.Format(time.RFC3339)))
+	}
+
+	if strings.TrimSpace(similar.Resolution) != "" {
+		b.WriteString(fmt.Sprintf("Previous resolution: %s\n", strings.TrimSpace(similar.Resolution)))
+	}
+
+	if strings.TrimSpace(similar.URL) != "" {
+		b.WriteString(fmt.Sprintf("View: %s\n", strings.TrimSpace(similar.URL)))
+	}
+
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func formatSimilarityPercent(score float64) string {
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+
+	return fmt.Sprintf("%.0f%%", score*100)
+}
+
+func truncateRunes(value string, max int) string {
+	value = strings.TrimSpace(value)
+
+	if max <= 0 {
+		return ""
+	}
+
+	if utf8.RuneCountInString(value) <= max {
+		return value
+	}
+
+	runes := []rune(value)
+	if max <= 3 {
+		return string(runes[:max])
+	}
+
+	return strings.TrimSpace(string(runes[:max-3])) + "..."
+}
+
+func runeLen(value string) int {
+	return utf8.RuneCountInString(value)
+}

--- a/internal/notify/similar_incident.go
+++ b/internal/notify/similar_incident.go
@@ -43,90 +43,37 @@ type SimilarIncident struct {
 
 // SendIncidentAlertWithSimilar sends the normal Slack incident alert and, when
 // present, includes the most similar past incident.
+
 func (s *SlackNotifier) SendIncidentAlertWithSimilar(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse, similar *SimilarIncident) error {
-	text := fmt.Sprintf("*Alert:* %s", incident.Title)
-
-	onCallText := "Unassigned"
-	if onCallUser != nil {
-		onCallText = fmt.Sprintf("%s <%s>", onCallUser.Name, onCallUser.Email)
+	if similar == nil {
+		return s.SendIncidentAlert(ctx, incident, onCallUser, analysis)
 	}
 
-	message := SlackMessage{
-		Channel: s.channel,
-		Text:    text,
-		Blocks: []Block{
-			{
-				Type: "section",
-				Text: &Text{
-					Type: "mrkdwn",
-					Text: text,
-				},
-			},
-			{
-				Type: "section",
-				Text: &Text{
-					Type: "mrkdwn",
-					Text: fmt.Sprintf(
-						"*Severity:* %s\n*Source:* %s\n*On-Call:* %s",
-						incident.Severity,
-						incident.Source,
-						onCallText,
-					),
-				},
-			},
-		},
-	}
+	message := s.buildIncidentAlertMessage(incident, onCallUser, analysis)
 
-	if incident.Message != nil && *incident.Message != "" {
-		message.Blocks = append(message.Blocks, Block{
-			Type: "section",
-			Text: &Text{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Message:* %s", *incident.Message),
-			},
-		})
-	}
-
-	if analysis != nil {
-		analysisText := fmt.Sprintf(
-			"*Root Cause Analysis:*\n\n*Probable Cause:* %s\n\n*Suggested Action:* %s\n\n*Confidence:* %s",
-			analysis.RootCause,
-			analysis.SuggestedAction,
-			analysis.Confidence,
-		)
-
-		message.Blocks = append(message.Blocks, Block{
-			Type: "section",
-			Text: &Text{
-				Type: "mrkdwn",
-				Text: analysisText,
-			},
-		})
-	}
-
-	if similar != nil {
-		message.Blocks = append(message.Blocks, Block{
-			Type: "section",
-			Text: &Text{
-				Type: "mrkdwn",
-				Text: formatSimilarIncidentSlack(similar),
-			},
-		})
-	}
-
-	message.Blocks = append(message.Blocks, Block{
+	message.Blocks = insertSlackBlockBeforeIncidentID(message.Blocks, Block{
 		Type: "section",
 		Text: &Text{
 			Type: "mrkdwn",
-			Text: fmt.Sprintf(
-				"*Incident ID:* `%s`\n*Fired at:* %s",
-				incident.ID.String(),
-				incident.FiredAt.Format(time.RFC3339),
-			),
+			Text: formatSimilarIncidentSlack(similar),
 		},
 	})
 
 	return s.sendMessage(ctx, message)
+}
+
+func insertSlackBlockBeforeIncidentID(blocks []Block, block Block) []Block {
+	for i := len(blocks) - 1; i >= 0; i-- {
+		if blocks[i].Text != nil && strings.Contains(blocks[i].Text.Text, "*Incident ID:*") {
+			updated := make([]Block, 0, len(blocks)+1)
+			updated = append(updated, blocks[:i]...)
+			updated = append(updated, block)
+			updated = append(updated, blocks[i:]...)
+			return updated
+		}
+	}
+
+	return append(blocks, block)
 }
 
 // SendIncidentAlertWithSimilar sends the normal email alert and, when present,

--- a/internal/notify/similar_incident.go
+++ b/internal/notify/similar_incident.go
@@ -280,19 +280,30 @@ func formatSimilarIncidentEmail(similar *SimilarIncident) string {
 
 	b.WriteString("Similar past incident\n")
 	b.WriteString("---------------------\n")
-	b.WriteString(fmt.Sprintf("Title: %s\n", title))
-	b.WriteString(fmt.Sprintf("Similarity: %s\n", formatSimilarityPercent(similar.Score)))
+	b.WriteString("Title: ")
+	b.WriteString(title)
+	b.WriteByte('\n')
+
+	b.WriteString("Similarity: ")
+	b.WriteString(formatSimilarityPercent(similar.Score))
+	b.WriteByte('\n')
 
 	if !similar.FiredAt.IsZero() {
-		b.WriteString(fmt.Sprintf("Fired at: %s\n", similar.FiredAt.Format(time.RFC3339)))
+		b.WriteString("Fired at: ")
+		b.WriteString(similar.FiredAt.Format(time.RFC3339))
+		b.WriteByte('\n')
 	}
 
 	if strings.TrimSpace(similar.Resolution) != "" {
-		b.WriteString(fmt.Sprintf("Previous resolution: %s\n", strings.TrimSpace(similar.Resolution)))
+		b.WriteString("Previous resolution: ")
+		b.WriteString(strings.TrimSpace(similar.Resolution))
+		b.WriteByte('\n')
 	}
 
 	if strings.TrimSpace(similar.URL) != "" {
-		b.WriteString(fmt.Sprintf("View: %s\n", strings.TrimSpace(similar.URL)))
+		b.WriteString("View: ")
+		b.WriteString(strings.TrimSpace(similar.URL))
+		b.WriteByte('\n')
 	}
 
 	b.WriteString("\n")

--- a/internal/notify/similar_incident_test.go
+++ b/internal/notify/similar_incident_test.go
@@ -28,7 +28,7 @@ func TestSlackNotifierSendIncidentAlertWithSimilarIncludesBlock(t *testing.T) {
 	var payload SlackMessage
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode slack payload: %v", err)

--- a/internal/notify/similar_incident_test.go
+++ b/internal/notify/similar_incident_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -63,6 +64,45 @@ func TestSlackNotifierSendIncidentAlertWithSimilarIncludesBlock(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected Slack payload to contain %q, got:\n%s", want, text)
 		}
+	}
+}
+
+func TestSlackNotifierSendIncidentAlertWithSimilarNilMatchesBaseAlert(t *testing.T) {
+	var payloads []SlackMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+
+		var payload SlackMessage
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode slack payload: %v", err)
+		}
+
+		payloads = append(payloads, payload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := newSlackNotifierWithClient(server.URL, "#alerts", server.Client())
+
+	incident := makeTestIncident()
+	member := makeTestMember()
+	analysis := makeTestAnalysis()
+
+	if err := notifier.SendIncidentAlert(context.Background(), incident, member, analysis); err != nil {
+		t.Fatalf("send base slack alert: %v", err)
+	}
+
+	if err := notifier.SendIncidentAlertWithSimilar(context.Background(), incident, member, analysis, nil); err != nil {
+		t.Fatalf("send slack alert with nil similar incident: %v", err)
+	}
+
+	if len(payloads) != 2 {
+		t.Fatalf("expected two Slack payloads, got %d", len(payloads))
+	}
+
+	if !reflect.DeepEqual(payloads[0], payloads[1]) {
+		t.Fatalf("expected nil similar path to match base Slack alert\nbase: %+v\nwith nil similar: %+v", payloads[0], payloads[1])
 	}
 }
 

--- a/internal/notify/similar_incident_test.go
+++ b/internal/notify/similar_incident_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 NTC Dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSlackNotifierSendIncidentAlertWithSimilarIncludesBlock(t *testing.T) {
+	var payload SlackMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode slack payload: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := newSlackNotifierWithClient(server.URL, "#alerts", server.Client())
+
+	err := notifier.SendIncidentAlertWithSimilar(context.Background(), makeTestIncident(), makeTestMember(), makeTestAnalysis(), &SimilarIncident{
+		Title:      "Payment timeout",
+		Score:      0.84,
+		Resolution: "rolled back v2.3.1",
+		URL:        "https://wachd.example.com/incidents/abc",
+		FiredAt:    time.Date(2026, 3, 12, 9, 30, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("send slack alert: %v", err)
+	}
+
+	text := collectSlackText(payload.Blocks)
+
+	for _, want := range []string{
+		"Similar past incident (84%)",
+		"Payment timeout",
+		"Previous resolution",
+		"rolled back v2.3.1",
+		"<https://wachd.example.com/incidents/abc|view>",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected Slack payload to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestEmailBuildBodyWithSimilarIncludesBlock(t *testing.T) {
+	notifier := &EmailNotifier{}
+
+	body := notifier.buildEmailBodyWithSimilar(makeTestIncident(), makeTestMember(), makeTestAnalysis(), &SimilarIncident{
+		Title:      "Payment timeout",
+		Score:      0.84,
+		Resolution: "rolled back v2.3.1",
+		URL:        "https://wachd.example.com/incidents/abc",
+		FiredAt:    time.Date(2026, 3, 12, 9, 30, 0, 0, time.UTC),
+	})
+
+	for _, want := range []string{
+		"Similar past incident",
+		"Payment timeout",
+		"Similarity: 84%",
+		"Previous resolution: rolled back v2.3.1",
+		"View: https://wachd.example.com/incidents/abc",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected email body to contain %q, got:\n%s", want, body)
+		}
+	}
+}
+
+func TestSMSBuildMessageWithSimilarStaysWithin160Chars(t *testing.T) {
+	notifier := &SMSNotifier{}
+
+	incident := makeTestIncident()
+	incident.Title = strings.Repeat("Checkout database outage ", 8)
+
+	analysis := makeTestAnalysis()
+	analysis.RootCause = strings.Repeat("database connection pool exhausted ", 8)
+
+	message := notifier.buildMessageWithSimilar(incident, analysis, &SimilarIncident{
+		Title: strings.Repeat("Checkout database pool incident ", 5),
+		Score: 0.84,
+	})
+
+	if runeLen(message) > maxSMSIncidentAlertChars {
+		t.Fatalf("expected SMS message to be <= %d chars, got %d: %q", maxSMSIncidentAlertChars, runeLen(message), message)
+	}
+
+	if !strings.Contains(message, "Similar:") {
+		t.Fatalf("expected SMS message to include similar incident sentence, got %q", message)
+	}
+
+	if !strings.Contains(message, "84%") {
+		t.Fatalf("expected SMS message to include similarity percent, got %q", message)
+	}
+}
+
+func collectSlackText(blocks []Block) string {
+	var parts []string
+
+	for _, block := range blocks {
+		if block.Text != nil {
+			parts = append(parts, block.Text.Text)
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -70,9 +70,18 @@ func newSlackNotifierWithClient(webhookURL, channel string, client *http.Client)
 }
 
 // SendIncidentAlert sends an incident alert to Slack
+
 func (s *SlackNotifier) SendIncidentAlert(ctx context.Context, incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse) error {
-	// Format the message
-	text := fmt.Sprintf("🚨 *Alert:* %s", incident.Title)
+	return s.sendMessage(ctx, s.buildIncidentAlertMessage(incident, onCallUser, analysis))
+}
+
+func (s *SlackNotifier) buildIncidentAlertMessage(incident *store.Incident, onCallUser *store.TeamMember, analysis *ai.AnalysisResponse) SlackMessage {
+	text := fmt.Sprintf("*Alert:* %s", incident.Title)
+
+	onCallText := "Unassigned"
+	if onCallUser != nil {
+		onCallText = fmt.Sprintf("%s <%s>", onCallUser.Name, onCallUser.Email)
+	}
 
 	message := SlackMessage{
 		Channel: s.channel,
@@ -89,18 +98,17 @@ func (s *SlackNotifier) SendIncidentAlert(ctx context.Context, incident *store.I
 				Type: "section",
 				Text: &Text{
 					Type: "mrkdwn",
-					Text: fmt.Sprintf("*Severity:* %s\n*Source:* %s\n*On-Call:* %s <%s>",
+					Text: fmt.Sprintf(
+						"*Severity:* %s\n*Source:* %s\n*On-Call:* %s",
 						incident.Severity,
 						incident.Source,
-						onCallUser.Name,
-						onCallUser.Email,
+						onCallText,
 					),
 				},
 			},
 		},
 	}
 
-	// Add message if present
 	if incident.Message != nil && *incident.Message != "" {
 		message.Blocks = append(message.Blocks, Block{
 			Type: "section",
@@ -111,9 +119,9 @@ func (s *SlackNotifier) SendIncidentAlert(ctx context.Context, incident *store.I
 		})
 	}
 
-	// Add root cause analysis if available
 	if analysis != nil {
-		analysisText := fmt.Sprintf("🤖 *Root Cause Analysis:*\n\n*Probable Cause:* %s\n\n*Suggested Action:* %s\n\n*Confidence:* %s",
+		analysisText := fmt.Sprintf(
+			"*Root Cause Analysis:*\n\n*Probable Cause:* %s\n\n*Suggested Action:* %s\n\n*Confidence:* %s",
 			analysis.RootCause,
 			analysis.SuggestedAction,
 			analysis.Confidence,
@@ -128,20 +136,19 @@ func (s *SlackNotifier) SendIncidentAlert(ctx context.Context, incident *store.I
 		})
 	}
 
-	// Add incident ID
 	message.Blocks = append(message.Blocks, Block{
 		Type: "section",
 		Text: &Text{
 			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Incident ID:* `%s`\n*Fired at:* %s",
+			Text: fmt.Sprintf(
+				"*Incident ID:* `%s`\n*Fired at:* %s",
 				incident.ID.String(),
 				incident.FiredAt.Format(time.RFC3339),
 			),
 		},
 	})
 
-	// Send the message
-	return s.sendMessage(ctx, message)
+	return message
 }
 
 // SendTestMessage sends a simple test message to verify the Slack webhook is working.


### PR DESCRIPTION
## Summary

Closes #43.

This PR adds similar past incident context to alert notifications.

When an alert is processed, the worker now:

- builds a pending incident graph node after AI analysis
- respects `team_graph_config.enabled`
- calls `FindSimilar(..., limit=1)`
- includes the top match only when `score >= 0.50`
- safely skips similar incident context if graph lookup fails
- passes the optional similar incident into Slack, email, and SMS notifications

Notification behavior:

- Slack includes title, score, previous resolution, date, and dashboard link
- Email includes title, score, previous resolution, date, and dashboard link
- SMS appends one short similar-incident sentence and stays within 160 characters

The dashboard link uses `WACHD_DASHBOARD_URL` when set, and falls back to `http://localhost:3000`.

## Why

This gives the on-call engineer immediate historical context directly in the alert notification:

> This looks like a previous incident, and here is how it was resolved.

That means responders can see the likely previous fix before opening the dashboard.

## Fail-safe behavior

Similar incident lookup is best-effort only.

If graph config is disabled, no graph node is written and no similar block is added.

If graph lookup fails, notifications still send normally.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing

Added unit coverage for:

- similar incident notification included when score is `>= 0.50`
- similar incident notification omitted when score is below `0.50`
- similar incident notification omitted when `FindSimilar` errors
- similar incident notification omitted when graph is disabled
- Slack similar incident block formatting
- email similar incident block formatting
- SMS similar incident formatting capped at 160 characters

Added worker integration coverage for:

- a second similar incident finding the first resolved incident through the graph
- a team with no graph history returning no similar incident context

Commands run:

```bash
go test ./internal/notify
go test ./cmd/worker
go test ./...
make test
go build ./...
go vet ./...
```

- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

Closes #43.