### PR TITLE
feat(web): add incident timeline view (#38)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"net/netip"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -607,6 +608,7 @@ func main() {
 	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/similar", server.handleGetSimilarIncidents).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/graph", server.handleGetIncidentGraph).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/promote", server.handlePromoteIncidentGraphNode).Methods("POST")
+	apiRouter.HandleFunc("/{teamId}/incidents/{incidentId}/timeline", server.handleGetIncidentTimeline).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/dependencies", server.handleListServiceDependencies).Methods("GET")
 	apiRouter.HandleFunc("/{teamId}/dependencies", server.handleCreateServiceDependency).Methods("POST")
 	apiRouter.HandleFunc("/{teamId}/dependencies/{depId}", server.handleDeleteServiceDependency).Methods("DELETE")
@@ -2038,6 +2040,162 @@ func (s *Server) handlePromoteIncidentGraphNode(w http.ResponseWriter, r *http.R
 		return
 	}
 	writeDataEnvelope(w, http.StatusOK, map[string]string{"status": "promoted", "node_id": node.ID.String()})
+}
+
+// timelineEvent is a single chronological event in an incident's lifecycle.
+type timelineEvent struct {
+	Time   time.Time         `json:"time"`
+	Kind   string            `json:"kind"`
+	Title  string            `json:"title"`
+	Detail string            `json:"detail,omitempty"`
+	Meta   map[string]string `json:"meta,omitempty"`
+}
+
+// GET /api/v1/teams/{teamId}/incidents/{incidentId}/timeline
+func (s *Server) handleGetIncidentTimeline(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	teamID, err := uuid.Parse(vars["teamId"])
+	if err != nil {
+		http.Error(w, "invalid team ID", http.StatusBadRequest)
+		return
+	}
+	incidentID, err := uuid.Parse(vars["incidentId"])
+	if err != nil {
+		http.Error(w, "invalid incident ID", http.StatusBadRequest)
+		return
+	}
+	if !s.requireTeamAccess(r, teamID) {
+		writeForbidden(w)
+		return
+	}
+
+	incident, err := s.db.GetIncident(r.Context(), teamID, incidentID)
+	if err != nil {
+		log.Printf("handleGetIncidentTimeline: get incident: %v", err)
+		http.Error(w, "failed to load incident", http.StatusInternalServerError)
+		return
+	}
+	if incident == nil {
+		http.Error(w, "incident not found", http.StatusNotFound)
+		return
+	}
+
+	var events []timelineEvent
+
+	// Alert fired
+	events = append(events, timelineEvent{
+		Time:   incident.FiredAt,
+		Kind:   "alert_fired",
+		Title:  "Alert fired",
+		Detail: incident.Title,
+		Meta:   map[string]string{"source": incident.Source, "severity": incident.Severity},
+	})
+
+	// Commits and first log spike from collected context
+	if len(incident.Context) > 0 {
+		var ctx struct {
+			Commits []struct {
+				SHA       string    `json:"sha"`
+				Message   string    `json:"message"`
+				Author    string    `json:"author"`
+				Timestamp time.Time `json:"timestamp"`
+			} `json:"commits"`
+			Logs []struct {
+				Timestamp time.Time `json:"timestamp"`
+				Message   string    `json:"message"`
+				Level     string    `json:"level"`
+			} `json:"logs"`
+		}
+		if err := json.Unmarshal(incident.Context, &ctx); err == nil {
+			for _, c := range ctx.Commits {
+				if c.Timestamp.IsZero() {
+					continue
+				}
+				sha := c.SHA
+				if len(sha) > 7 {
+					sha = sha[:7]
+				}
+				events = append(events, timelineEvent{
+					Time:   c.Timestamp,
+					Kind:   "commit",
+					Title:  fmt.Sprintf("Commit by %s", c.Author),
+					Detail: c.Message,
+					Meta:   map[string]string{"sha": sha, "author": c.Author},
+				})
+			}
+			// Emit one event for the first error/warn log entry
+			for _, l := range ctx.Logs {
+				lvl := strings.ToLower(l.Level)
+				if lvl == "error" || lvl == "warn" || lvl == "warning" || lvl == "critical" {
+					events = append(events, timelineEvent{
+						Time:   l.Timestamp,
+						Kind:   "log_spike",
+						Title:  "Error logs detected",
+						Detail: l.Message,
+						Meta:   map[string]string{"level": l.Level},
+					})
+					break
+				}
+			}
+		}
+	}
+
+	// AI root cause analysis
+	if len(incident.Analysis) > 0 {
+		var analysis struct {
+			RootCause  string `json:"root_cause"`
+			Confidence string `json:"confidence"`
+		}
+		if err := json.Unmarshal(incident.Analysis, &analysis); err == nil && analysis.RootCause != "" {
+			events = append(events, timelineEvent{
+				Time:   incident.UpdatedAt,
+				Kind:   "analysis_complete",
+				Title:  "AI root cause analysis complete",
+				Detail: analysis.RootCause,
+				Meta:   map[string]string{"confidence": analysis.Confidence},
+			})
+		}
+	}
+
+	// Sent notifications
+	notifEvents, err := s.db.GetIncidentNotificationEvents(r.Context(), teamID, incidentID)
+	if err != nil {
+		log.Printf("handleGetIncidentTimeline: get notifications: %v", err)
+		// Non-fatal — return partial timeline without notification events
+	} else {
+		for _, n := range notifEvents {
+			events = append(events, timelineEvent{
+				Time:  n.SentAt,
+				Kind:  "notification_sent",
+				Title: fmt.Sprintf("%s notified via %s", n.Username, n.Channel),
+				Meta:  map[string]string{"channel": n.Channel, "username": n.Username},
+			})
+		}
+	}
+
+	// Acknowledged
+	if incident.AcknowledgedAt != nil {
+		events = append(events, timelineEvent{
+			Time:  *incident.AcknowledgedAt,
+			Kind:  "acknowledged",
+			Title: "Incident acknowledged",
+		})
+	}
+
+	// Resolved
+	if incident.ResolvedAt != nil {
+		events = append(events, timelineEvent{
+			Time:  *incident.ResolvedAt,
+			Kind:  "resolved",
+			Title: "Incident resolved",
+		})
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Time.Before(events[j].Time)
+	})
+
+	writeDataEnvelope(w, http.StatusOK, events)
 }
 
 func (s *Server) handleListGraphNodes(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/incidents.go
+++ b/internal/store/incidents.go
@@ -313,6 +313,39 @@ func (db *DB) GetOpenIncidentsForEscalation(ctx context.Context, minAge time.Dur
 	return incidents, rows.Err()
 }
 
+// NotificationEvent represents a sent notification for timeline display.
+type NotificationEvent struct {
+	SentAt   time.Time `json:"sent_at"`
+	Channel  string    `json:"channel"`
+	Username string    `json:"username"`
+}
+
+// GetIncidentNotificationEvents returns notifications that were sent for an incident,
+// joined with user names for display. Only rows with a non-null sent_at are returned.
+func (db *DB) GetIncidentNotificationEvents(ctx context.Context, teamID, incidentID uuid.UUID) ([]*NotificationEvent, error) {
+	rows, err := db.pool.Query(ctx, `
+		SELECT pn.sent_at, pn.channel, COALESCE(u.username, 'unknown')
+		FROM pending_notifications pn
+		LEFT JOIN users u ON u.id = pn.user_id
+		WHERE pn.incident_id = $1 AND pn.team_id = $2 AND pn.sent_at IS NOT NULL
+		ORDER BY pn.sent_at ASC
+	`, incidentID, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("query notification events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []*NotificationEvent
+	for rows.Next() {
+		e := &NotificationEvent{}
+		if err := rows.Scan(&e.SentAt, &e.Channel, &e.Username); err != nil {
+			return nil, fmt.Errorf("scan notification event: %w", err)
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
 // IncrementEscalationStep advances the escalation_step by 1 only when the current
 // value matches fromStep. Returns true if the row was updated (i.e. this caller
 // "won" the escalation — prevents double-escalation with concurrent workers).

--- a/web/app/incidents/[id]/page.tsx
+++ b/web/app/incidents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
 import SimilarIncidentsPanel from '@/components/similar-incidents-panel';
+import IncidentTimeline from '@/components/incident-timeline';
 import { api } from '@/lib/api';
 import { useSession } from '@/lib/session-context';
 import type { Incident } from '@/lib/types';
@@ -335,6 +336,10 @@ export default function IncidentDetailPage() {
               </div>
             )}
           </div>
+        )}
+
+        {primaryTeamId && (
+          <IncidentTimeline teamId={primaryTeamId} incidentId={incident.id} />
         )}
 
         {primaryTeamId && (

--- a/web/components/incident-timeline.tsx
+++ b/web/components/incident-timeline.tsx
@@ -36,6 +36,9 @@ export default function IncidentTimeline({ teamId, incidentId }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setLoading(true);
+    setError(null);
+
     api.incidents.timeline(teamId, incidentId)
       .then(setEvents)
       .catch(() => setError('Failed to load timeline'))

--- a/web/components/incident-timeline.tsx
+++ b/web/components/incident-timeline.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import type { TimelineEvent } from '@/lib/types';
+
+interface Props {
+  teamId: string;
+  incidentId: string;
+}
+
+const KIND_CONFIG: Record<
+  TimelineEvent['kind'],
+  { label: string; color: string; dot: string }
+> = {
+  alert_fired:        { label: 'Alert fired',       color: 'text-red-600',    dot: 'bg-red-500' },
+  commit:             { label: 'Commit',             color: 'text-gray-700',   dot: 'bg-blue-400' },
+  log_spike:          { label: 'Error logs',         color: 'text-orange-600', dot: 'bg-orange-400' },
+  analysis_complete:  { label: 'AI analysis',        color: 'text-purple-600', dot: 'bg-purple-500' },
+  notification_sent:  { label: 'Notified',           color: 'text-blue-600',   dot: 'bg-blue-500' },
+  acknowledged:       { label: 'Acknowledged',       color: 'text-green-600',  dot: 'bg-green-400' },
+  resolved:           { label: 'Resolved',           color: 'text-green-700',  dot: 'bg-green-600' },
+};
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+export default function IncidentTimeline({ teamId, incidentId }: Props) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.incidents.timeline(teamId, incidentId)
+      .then(setEvents)
+      .catch(() => setError('Failed to load timeline'))
+      .finally(() => setLoading(false));
+  }, [teamId, incidentId]);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Timeline</h2>
+        <div className="animate-pulse space-y-4">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="flex gap-3">
+              <div className="w-3 h-3 rounded-full bg-gray-200 mt-1 flex-shrink-0" />
+              <div className="flex-1 space-y-1">
+                <div className="h-3 bg-gray-200 rounded w-1/3" />
+                <div className="h-3 bg-gray-200 rounded w-2/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Timeline</h2>
+        <p className="text-sm text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Timeline</h2>
+        <p className="text-sm text-gray-500">No events recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-6">Timeline</h2>
+      <ol className="relative">
+        {events.map((event, idx) => {
+          const cfg = KIND_CONFIG[event.kind] ?? {
+            label: event.kind,
+            color: 'text-gray-600',
+            dot: 'bg-gray-400',
+          };
+          const isLast = idx === events.length - 1;
+          return (
+            <li key={idx} className="flex gap-4">
+              {/* Dot + vertical line */}
+              <div className="flex flex-col items-center">
+                <span className={`w-3 h-3 rounded-full flex-shrink-0 mt-0.5 ${cfg.dot}`} />
+                {!isLast && <span className="w-px flex-1 bg-gray-200 my-1" />}
+              </div>
+
+              {/* Content */}
+              <div className={`pb-6 ${isLast ? '' : ''}`}>
+                <p className={`text-sm font-medium ${cfg.color}`}>{event.title}</p>
+                {event.detail && (
+                  <p className="text-sm text-gray-600 mt-0.5 leading-snug">{event.detail}</p>
+                )}
+                {event.meta && Object.keys(event.meta).length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    {Object.entries(event.meta).map(([k, v]) => (
+                      <span key={k} className="inline-flex items-center text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5">
+                        {k}: {v}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <p className="text-xs text-gray-400 mt-1">
+                  {formatDate(event.time)} · {formatTime(event.time)}
+                </p>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,6 +1,6 @@
 // API client for the Wachd backend
 
-import type { Incident, TeamMember, Schedule, OnCallUser, ScheduleOverride, SimilarIncident, GraphConfig, GraphNode, IncidentGraph } from './types';
+import type { Incident, TeamMember, Schedule, OnCallUser, ScheduleOverride, SimilarIncident, GraphConfig, GraphNode, IncidentGraph, TimelineEvent } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
@@ -138,6 +138,13 @@ export const api = {
         method: 'POST',
         body: JSON.stringify({ minutes }),
       }),
+
+    timeline: async (teamId: string, incidentId: string): Promise<TimelineEvent[]> => {
+      const response = await fetchApi<GraphEnvelope<TimelineEvent[]> | TimelineEvent[]>(
+        `/api/v1/teams/${teamId}/incidents/${incidentId}/timeline`
+      );
+      return unwrapGraphData(response) ?? [];
+    },
   },
 
   // On-call schedule

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -155,3 +155,18 @@ export interface IncidentGraph {
   nodes: GraphNode[];
   edges: GraphEdge[];
 }
+
+export interface TimelineEvent {
+  time: string;
+  kind:
+    | 'alert_fired'
+    | 'commit'
+    | 'log_spike'
+    | 'analysis_complete'
+    | 'notification_sent'
+    | 'acknowledged'
+    | 'resolved';
+  title: string;
+  detail?: string;
+  meta?: Record<string, string>;
+}


### PR DESCRIPTION
## Summary

- New `GET /api/v1/teams/{teamId}/incidents/{incidentId}/timeline` endpoint that composes chronological events from incident fields, context JSONB (commits + first log spike), analysis JSONB, and sent notifications
- `GetIncidentNotificationEvents` store method — queries `pending_notifications` joined with users for display names, scoped by `team_id` + `incident_id`
- `IncidentTimeline` React component — vertical dot/line timeline with per-kind colours, loading skeleton, and meta badges
- `TimelineEvent` type added to `types.ts`; `api.incidents.timeline()` added to `api.ts`
- Timeline rendered above `SimilarIncidentsPanel` on the incident detail page

Closes #38

## Test plan

- [ ] `GET /api/v1/teams/{teamId}/incidents/{incidentId}/timeline` returns ordered events with correct `kind` values (`alert_fired`, `commit`, `log_spike`, `ai_analysis`, `notification_sent`)
- [ ] Timeline endpoint returns 404 for unknown incident ID
- [ ] Timeline endpoint returns 403 for incident belonging to a different team (tenant isolation)
- [ ] Frontend loading skeleton renders while request is in-flight
- [ ] Each event kind renders with correct colour and icon
- [ ] Component renders correctly when notification events are empty (no pending_notifications rows)
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `cd web && npm run build` passes