### PR TITLE
feat(ai): make OpenAI base URL configurable

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -195,11 +195,12 @@ func main() {
 
 	case "openai":
 		apiKey := os.Getenv("OPENAI_API_KEY")
+		baseURL := os.Getenv("OPENAI_BASE_URL")
 		model := ""
 		if sc.AIModel != nil {
 			model = *sc.AIModel
 		}
-		aiEngine = ai.NewOpenAIBackend(apiKey, model)
+		aiEngine = ai.NewOpenAIBackend(apiKey, model, baseURL)
 		if aiEngine.IsAvailable(context.Background()) {
 			log.Printf("✓ OpenAI backend configured (model: %s)", aiEngine.GetModelName())
 		} else {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -196,11 +196,12 @@ func main() {
 	case "openai":
 		apiKey := os.Getenv("OPENAI_API_KEY")
 		baseURL := os.Getenv("OPENAI_BASE_URL")
+		apiVersion := os.Getenv("OPENAI_API_VERSION")
 		model := ""
 		if sc.AIModel != nil {
 			model = *sc.AIModel
 		}
-		aiEngine = ai.NewOpenAIBackend(apiKey, model, baseURL)
+		aiEngine = ai.NewOpenAIBackend(apiKey, model, baseURL, apiVersion)
 		if aiEngine.IsAvailable(context.Background()) {
 			log.Printf("✓ OpenAI backend configured (model: %s)", aiEngine.GetModelName())
 		} else {

--- a/helm/wachd/README.md
+++ b/helm/wachd/README.md
@@ -66,10 +66,35 @@ Set `analysis.backend` to one of:
 |---|---|
 | `ollama` | Local LLM — air-gapped, no external API calls (default) |
 | `claude` | Anthropic Claude — highest quality analysis |
-| `openai` | OpenAI GPT-4o |
+| `openai` | OpenAI GPT-4o, or any OpenAI-compatible endpoint |
 | `gemini` | Google Gemini — free tier available |
 
 For air-gapped deployments, set `analysis.ollama.enabled: true` to deploy Ollama in-cluster alongside Wachd.
+
+### OpenAI-compatible endpoints
+
+`analysis.backend: openai` works with any OpenAI-compatible server — not just OpenAI itself. Set `analysis.openaiBaseURL` to point at a self-hosted inference server:
+
+```yaml
+# vLLM or LLMKube InferenceService (llama.cpp on 8080, vLLM on 8000)
+analysis:
+  backend: openai
+  openaiBaseURL: "http://<inferenceservice-name>.<namespace>.svc.cluster.local:8080/v1"
+
+# Azure OpenAI
+analysis:
+  backend: openai
+  openaiBaseURL: "https://<resource>.openai.azure.com/openai/deployments/<deployment>"
+  openaiAPIVersion: "2024-02-01"
+
+# Groq, Together.ai, or any other compatible provider
+analysis:
+  backend: openai
+  openaiBaseURL: "https://api.groq.com/openai/v1"
+```
+
+Leave `openaiBaseURL` empty to use `https://api.openai.com/v1` (default).
+Azure OpenAI is detected automatically from the URL — the correct `api-key` auth header is set without any extra configuration.
 
 ## Authentication
 

--- a/helm/wachd/templates/configmap.yaml
+++ b/helm/wachd/templates/configmap.yaml
@@ -20,6 +20,9 @@ data:
   CLAUDE_MODEL: {{ .Values.analysis.claudeModel | quote }}
   {{- else if eq .Values.analysis.backend "openai" }}
   OPENAI_MODEL: {{ .Values.analysis.openaiModel | quote }}
+  {{- if .Values.analysis.openaiBaseURL }}
+  OPENAI_BASE_URL: {{ .Values.analysis.openaiBaseURL | quote }}
+  {{- end }}
   {{- else if eq .Values.analysis.backend "gemini" }}
   GEMINI_MODEL: {{ .Values.analysis.geminiModel | quote }}
   {{- end }}

--- a/helm/wachd/templates/configmap.yaml
+++ b/helm/wachd/templates/configmap.yaml
@@ -23,6 +23,9 @@ data:
   {{- if .Values.analysis.openaiBaseURL }}
   OPENAI_BASE_URL: {{ .Values.analysis.openaiBaseURL | quote }}
   {{- end }}
+  {{- if .Values.analysis.openaiAPIVersion }}
+  OPENAI_API_VERSION: {{ .Values.analysis.openaiAPIVersion | quote }}
+  {{- end }}
   {{- else if eq .Values.analysis.backend "gemini" }}
   GEMINI_MODEL: {{ .Values.analysis.geminiModel | quote }}
   {{- end }}

--- a/helm/wachd/values.yaml
+++ b/helm/wachd/values.yaml
@@ -472,6 +472,10 @@ analysis:
   openaiApiKeySecret: wachd-openai-key
   openaiApiKeyKey: api-key
   openaiModel: gpt-4o-mini
+  # Override to point at any OpenAI-compatible endpoint.
+  # Examples: vLLM, LLMKube InferenceService, Azure OpenAI, Groq, Together.ai.
+  # Leave empty to use the default https://api.openai.com/v1
+  openaiBaseURL: ""
 
   # ---------------------------------------------------------------------------
   # Gemini (Google) — free tier available, fast

--- a/helm/wachd/values.yaml
+++ b/helm/wachd/values.yaml
@@ -473,8 +473,13 @@ analysis:
   openaiApiKeyKey: api-key
   openaiModel: gpt-4o-mini
   # Override to point at any OpenAI-compatible endpoint.
-  # Examples: vLLM, LLMKube InferenceService, Azure OpenAI, Groq, Together.ai.
   # Leave empty to use the default https://api.openai.com/v1
+  #
+  # LLMKube InferenceService (llama.cpp backend listens on 8080, vLLM on 8000):
+  #   openaiBaseURL: "http://<inferenceservice-name>.<namespace>.svc.cluster.local:8080/v1"
+  # The exact URL is published on the InferenceService resource at .status.endpoint
+  #
+  # Other examples: Azure OpenAI, Groq, Together.ai, self-hosted vLLM.
   openaiBaseURL: ""
 
   # ---------------------------------------------------------------------------

--- a/helm/wachd/values.yaml
+++ b/helm/wachd/values.yaml
@@ -479,8 +479,14 @@ analysis:
   #   openaiBaseURL: "http://<inferenceservice-name>.<namespace>.svc.cluster.local:8080/v1"
   # The exact URL is published on the InferenceService resource at .status.endpoint
   #
-  # Other examples: Azure OpenAI, Groq, Together.ai, self-hosted vLLM.
+  # Azure OpenAI:
+  #   openaiBaseURL: "https://<resource>.openai.azure.com/openai/deployments/<deployment>"
+  #   openaiAPIVersion: "2024-02-01"
+  #
+  # Other examples: Groq, Together.ai, self-hosted vLLM.
   openaiBaseURL: ""
+  # API version query parameter — required for Azure OpenAI, leave empty for all other providers.
+  openaiAPIVersion: ""
 
   # ---------------------------------------------------------------------------
   # Gemini (Google) — free tier available, fast

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -371,30 +371,30 @@ func TestClaudeBackend_Analyze_EmptyContent(t *testing.T) {
 // ── OpenAIBackend ─────────────────────────────────────────────────────────────
 
 func TestOpenAIBackend_GetModelName(t *testing.T) {
-	b := NewOpenAIBackend("key", "gpt-4o")
+	b := NewOpenAIBackend("key", "gpt-4o", "")
 	if b.GetModelName() != "gpt-4o" {
 		t.Errorf("unexpected model: %q", b.GetModelName())
 	}
 }
 
 func TestOpenAIBackend_DefaultModel(t *testing.T) {
-	b := NewOpenAIBackend("key", "")
+	b := NewOpenAIBackend("key", "", "")
 	if b.GetModelName() == "" {
 		t.Error("expected default model")
 	}
 }
 
 func TestOpenAIBackend_IsAvailable(t *testing.T) {
-	if !NewOpenAIBackend("key", "").IsAvailable(context.Background()) {
+	if !NewOpenAIBackend("key", "", "").IsAvailable(context.Background()) {
 		t.Error("expected true with key")
 	}
-	if NewOpenAIBackend("", "").IsAvailable(context.Background()) {
+	if NewOpenAIBackend("", "", "").IsAvailable(context.Background()) {
 		t.Error("expected false without key")
 	}
 }
 
 func TestOpenAIBackend_Analyze_NoKey(t *testing.T) {
-	b := NewOpenAIBackend("", "")
+	b := NewOpenAIBackend("", "", "")
 	_, err := b.Analyze(context.Background(), "prompt")
 	if err == nil {
 		t.Error("expected error when no API key")

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -371,30 +371,30 @@ func TestClaudeBackend_Analyze_EmptyContent(t *testing.T) {
 // ── OpenAIBackend ─────────────────────────────────────────────────────────────
 
 func TestOpenAIBackend_GetModelName(t *testing.T) {
-	b := NewOpenAIBackend("key", "gpt-4o", "")
+	b := NewOpenAIBackend("key", "gpt-4o", "", "")
 	if b.GetModelName() != "gpt-4o" {
 		t.Errorf("unexpected model: %q", b.GetModelName())
 	}
 }
 
 func TestOpenAIBackend_DefaultModel(t *testing.T) {
-	b := NewOpenAIBackend("key", "", "")
+	b := NewOpenAIBackend("key", "", "", "")
 	if b.GetModelName() == "" {
 		t.Error("expected default model")
 	}
 }
 
 func TestOpenAIBackend_IsAvailable(t *testing.T) {
-	if !NewOpenAIBackend("key", "", "").IsAvailable(context.Background()) {
+	if !NewOpenAIBackend("key", "", "", "").IsAvailable(context.Background()) {
 		t.Error("expected true with key")
 	}
-	if NewOpenAIBackend("", "", "").IsAvailable(context.Background()) {
+	if NewOpenAIBackend("", "", "", "").IsAvailable(context.Background()) {
 		t.Error("expected false without key")
 	}
 }
 
 func TestOpenAIBackend_Analyze_NoKey(t *testing.T) {
-	b := NewOpenAIBackend("", "", "")
+	b := NewOpenAIBackend("", "", "", "")
 	_, err := b.Analyze(context.Background(), "prompt")
 	if err == nil {
 		t.Error("expected error when no API key")
@@ -461,6 +461,77 @@ func TestOpenAIBackend_Analyze_APIError(t *testing.T) {
 	_, err := b.Analyze(context.Background(), "prompt")
 	if err == nil {
 		t.Error("expected error for 429 response")
+	}
+}
+
+func TestOpenAIBackend_Analyze_AzureAuthHeader(t *testing.T) {
+	var gotAuthHeader, gotAPIKeyHeader string
+	b := &OpenAIBackend{
+		apiKey:  "my-azure-key",
+		model:   "gpt-4o",
+		baseURL: "https://myresource.openai.azure.com/openai/deployments/my-deployment",
+		client: mockClient(func(w http.ResponseWriter, r *http.Request) {
+			gotAuthHeader = r.Header.Get("Authorization")
+			gotAPIKeyHeader = r.Header.Get("api-key")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OpenAIResponse{
+				Choices: []struct {
+					Index   int `json:"index"`
+					Message struct {
+						Role    string `json:"role"`
+						Content string `json:"content"`
+					} `json:"message"`
+					FinishReason string `json:"finish_reason"`
+				}{{Message: struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{Content: "ok"}}},
+			})
+		}),
+	}
+
+	if _, err := b.Analyze(context.Background(), "prompt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAPIKeyHeader != "my-azure-key" {
+		t.Errorf("expected api-key header %q, got %q", "my-azure-key", gotAPIKeyHeader)
+	}
+	if gotAuthHeader != "" {
+		t.Errorf("expected no Authorization header for Azure, got %q", gotAuthHeader)
+	}
+}
+
+func TestOpenAIBackend_Analyze_APIVersionQueryParam(t *testing.T) {
+	var gotURL string
+	b := &OpenAIBackend{
+		apiKey:     "sk-test",
+		model:      "gpt-4o-mini",
+		baseURL:    "https://myresource.openai.azure.com/openai/deployments/my-deployment",
+		apiVersion: "2024-02-01",
+		client: mockClient(func(w http.ResponseWriter, r *http.Request) {
+			gotURL = r.URL.String()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OpenAIResponse{
+				Choices: []struct {
+					Index   int `json:"index"`
+					Message struct {
+						Role    string `json:"role"`
+						Content string `json:"content"`
+					} `json:"message"`
+					FinishReason string `json:"finish_reason"`
+				}{{Message: struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{Content: "ok"}}},
+			})
+		}),
+	}
+
+	if _, err := b.Analyze(context.Background(), "prompt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotURL, "api-version=2024-02-01") {
+		t.Errorf("expected api-version query param in URL, got %q", gotURL)
 	}
 }
 

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -464,6 +464,93 @@ func TestOpenAIBackend_Analyze_APIError(t *testing.T) {
 	}
 }
 
+func TestOpenAIBackend_DefaultBaseURL(t *testing.T) {
+	var gotURL string
+	b := NewOpenAIBackend("sk-test", "", "", "")
+	b.client = mockClient(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenAIResponse{
+			Choices: []struct {
+				Index   int `json:"index"`
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{{Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Content: "ok"}}},
+		})
+	})
+
+	if _, err := b.Analyze(context.Background(), "prompt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotURL, "api.openai.com") {
+		t.Errorf("expected default api.openai.com in URL, got %q", gotURL)
+	}
+}
+
+func TestOpenAIBackend_CustomBaseURL(t *testing.T) {
+	var gotURL string
+	b := NewOpenAIBackend("sk-test", "", "https://custom.inference.local/v1", "")
+	b.client = mockClient(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenAIResponse{
+			Choices: []struct {
+				Index   int `json:"index"`
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{{Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Content: "ok"}}},
+		})
+	})
+
+	if _, err := b.Analyze(context.Background(), "prompt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotURL, "custom.inference.local") {
+		t.Errorf("expected custom host in URL, got %q", gotURL)
+	}
+}
+
+func TestOpenAIBackend_TrailingSlashTrimmed(t *testing.T) {
+	var gotURL string
+	b := NewOpenAIBackend("sk-test", "", "https://custom.inference.local/v1/", "")
+	b.client = mockClient(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenAIResponse{
+			Choices: []struct {
+				Index   int `json:"index"`
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{{Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Content: "ok"}}},
+		})
+	})
+
+	if _, err := b.Analyze(context.Background(), "prompt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(gotURL, "//chat/completions") {
+		t.Errorf("trailing slash not trimmed — got double slash in URL: %q", gotURL)
+	}
+}
+
 func TestOpenAIBackend_Analyze_AzureAuthHeader(t *testing.T) {
 	var gotAuthHeader, gotAPIKeyHeader string
 	b := &OpenAIBackend{

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -71,6 +71,7 @@ func NewOpenAIBackend(apiKey, model, baseURL string) *OpenAIBackend {
 	if baseURL == "" {
 		baseURL = "https://api.openai.com/v1"
 	}
+	baseURL = strings.TrimRight(baseURL, "/")
 
 	return &OpenAIBackend{
 		apiKey:  apiKey,

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -27,10 +27,11 @@ import (
 
 // OpenAIBackend implements AI backend using OpenAI API
 type OpenAIBackend struct {
-	apiKey  string
-	model   string
-	baseURL string
-	client  *http.Client
+	apiKey     string
+	model      string
+	baseURL    string
+	apiVersion string // non-empty appends ?api-version=... (required for Azure OpenAI)
+	client     *http.Client
 }
 
 // OpenAIRequest represents a request to OpenAI API
@@ -61,12 +62,13 @@ type OpenAIResponse struct {
 }
 
 // NewOpenAIBackend creates a new OpenAI backend.
-// baseURL overrides the default https://api.openai.com/v1 endpoint — use this
-// to point at any OpenAI-compatible server (vLLM, LLMKube, Azure OpenAI, etc.).
-// Pass an empty string to use the default.
-func NewOpenAIBackend(apiKey, model, baseURL string) *OpenAIBackend {
+// baseURL overrides the default https://api.openai.com/v1 — use this to point
+// at any OpenAI-compatible server (vLLM, LLMKube, Groq, Together.ai, etc.).
+// apiVersion, if non-empty, is appended as ?api-version=... — required for
+// Azure OpenAI (e.g. "2024-02-01"). Pass empty strings to use the defaults.
+func NewOpenAIBackend(apiKey, model, baseURL, apiVersion string) *OpenAIBackend {
 	if model == "" {
-		model = "gpt-4o-mini" // Cost-effective model for analysis
+		model = "gpt-4o-mini"
 	}
 	if baseURL == "" {
 		baseURL = "https://api.openai.com/v1"
@@ -74,9 +76,10 @@ func NewOpenAIBackend(apiKey, model, baseURL string) *OpenAIBackend {
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	return &OpenAIBackend{
-		apiKey:  apiKey,
-		model:   model,
-		baseURL: baseURL,
+		apiKey:     apiKey,
+		model:      model,
+		baseURL:    baseURL,
+		apiVersion: apiVersion,
 		client: &http.Client{
 			Timeout: 60 * time.Second,
 		},
@@ -104,13 +107,23 @@ func (o *OpenAIBackend) Analyze(ctx context.Context, prompt string) (string, err
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewBuffer(reqBody))
+	endpoint := o.baseURL + "/chat/completions"
+	if o.apiVersion != "" {
+		endpoint += "?api-version=" + o.apiVersion
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	// Azure OpenAI uses api-key header; all other compatible endpoints use Bearer.
+	if strings.Contains(o.baseURL, ".openai.azure.com") {
+		httpReq.Header.Set("api-key", o.apiKey)
+	} else {
+		httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	}
 
 	resp, err := o.client.Do(httpReq)
 	if err != nil {

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -27,9 +27,10 @@ import (
 
 // OpenAIBackend implements AI backend using OpenAI API
 type OpenAIBackend struct {
-	apiKey string
-	model  string
-	client *http.Client
+	apiKey  string
+	model   string
+	baseURL string
+	client  *http.Client
 }
 
 // OpenAIRequest represents a request to OpenAI API
@@ -59,15 +60,22 @@ type OpenAIResponse struct {
 	} `json:"choices"`
 }
 
-// NewOpenAIBackend creates a new OpenAI backend
-func NewOpenAIBackend(apiKey, model string) *OpenAIBackend {
+// NewOpenAIBackend creates a new OpenAI backend.
+// baseURL overrides the default https://api.openai.com/v1 endpoint — use this
+// to point at any OpenAI-compatible server (vLLM, LLMKube, Azure OpenAI, etc.).
+// Pass an empty string to use the default.
+func NewOpenAIBackend(apiKey, model, baseURL string) *OpenAIBackend {
 	if model == "" {
 		model = "gpt-4o-mini" // Cost-effective model for analysis
 	}
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
 
 	return &OpenAIBackend{
-		apiKey: apiKey,
-		model:  model,
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: baseURL,
 		client: &http.Client{
 			Timeout: 60 * time.Second,
 		},
@@ -95,7 +103,7 @@ func (o *OpenAIBackend) Analyze(ctx context.Context, prompt string) (string, err
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

The OpenAI backend had `api.openai.com` hardcoded, blocking any customer running an OpenAI-compatible inference server on their own infrastructure.

- `baseURL` field on `OpenAIBackend` — defaults to `https://api.openai.com/v1` when empty
- `OPENAI_BASE_URL` env var read in worker and passed through
- `analysis.openaiBaseURL` added to `values.yaml` (empty by default)
- `configmap.yaml` emits `OPENAI_BASE_URL` only when the value is set

With this change, operators can point Wachd's AI analysis at any OpenAI-compatible endpoint by setting one field:

```yaml
analysis:
  backend: openai
  openaiBaseURL: "http://llmkube-inference.default.svc.cluster.local/v1"
```

This works for: vLLM, LLMKube InferenceService, Azure OpenAI, Groq, Together.ai, Fireworks, or any self-hosted llama.cpp server.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/ai/...` passes
- [ ] Default behaviour unchanged: empty `openaiBaseURL` falls back to `api.openai.com/v1`
- [ ] Setting `analysis.openaiBaseURL` in values.yaml renders `OPENAI_BASE_URL` in the ConfigMap
- [ ] `OPENAI_BASE_URL` is absent from the ConfigMap when `openaiBaseURL` is empty