### PR TITLE
fix(agent): fix four Kubescape collector bugs

### DIFF
--- a/cmd/agent/collectors/kubescape/collector.go
+++ b/cmd/agent/collectors/kubescape/collector.go
@@ -62,7 +62,7 @@ const (
 	labelContainer   = "kubescape.io/workload-container-name"
 	labelContext     = "kubescape.io/context"
 
-	statusCompleted = "completed"
+	statusCompleted = "ready"
 )
 
 var (
@@ -102,7 +102,6 @@ func (s *State) isNew(key string, value int) bool {
 // Collector watches Kubescape summary CRDs and emits Events for net-new findings.
 type Collector struct {
 	client      dynamic.Interface
-	namespace   string // Kubescape installation namespace (default: "kubescape")
 	minSeverity string // threshold: "critical" or "high" (default: "high")
 	state       *State
 }
@@ -119,10 +118,6 @@ func New() (*Collector, error) {
 		return nil, fmt.Errorf("dynamic client: %w", err)
 	}
 
-	ns := os.Getenv("KUBESCAPE_NAMESPACE")
-	if ns == "" {
-		ns = "kubescape"
-	}
 	minSev := os.Getenv("KUBESCAPE_MIN_SEVERITY")
 	if minSev != "critical" {
 		minSev = "high"
@@ -130,7 +125,6 @@ func New() (*Collector, error) {
 
 	return &Collector{
 		client:      client,
-		namespace:   ns,
 		minSeverity: minSev,
 		state:       newState(),
 	}, nil
@@ -168,7 +162,7 @@ func (c *Collector) watchSummaries(ctx context.Context, gvr schema.GroupVersionR
 // stream from the resulting ResourceVersion. On any error the caller retries.
 func (c *Collector) runWatch(ctx context.Context, gvr schema.GroupVersionResource, kind string, out chan<- agent.Event) error {
 	// List first — prime in-memory state so we don't re-fire on restart.
-	list, err := c.client.Resource(gvr).Namespace(c.namespace).List(ctx, metav1.ListOptions{})
+	list, err := c.client.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("list: %w", err)
 	}
@@ -177,7 +171,7 @@ func (c *Collector) runWatch(ctx context.Context, gvr schema.GroupVersionResourc
 	}
 	rv := list.GetResourceVersion()
 
-	watcher, err := c.client.Resource(gvr).Namespace(c.namespace).Watch(ctx, metav1.ListOptions{
+	watcher, err := c.client.Resource(gvr).Namespace("").Watch(ctx, metav1.ListOptions{
 		ResourceVersion:     rv,
 		AllowWatchBookmarks: true,
 	})
@@ -186,7 +180,7 @@ func (c *Collector) runWatch(ctx context.Context, gvr schema.GroupVersionResourc
 	}
 	defer watcher.Stop()
 
-	log.Printf("kubescape: watching %s in namespace %s (rv=%s)", gvr.Resource, c.namespace, rv)
+	log.Printf("kubescape: watching %s across all namespaces (rv=%s)", gvr.Resource, rv)
 
 	for {
 		select {
@@ -202,8 +196,18 @@ func (c *Collector) runWatch(ctx context.Context, gvr schema.GroupVersionResourc
 			if we.Type != watch.Added && we.Type != watch.Modified {
 				continue
 			}
-			obj, ok := we.Object.(*unstructured.Unstructured)
+			// Kubescape's custom storage backend sends watch events with
+			// incomplete spec data — only metadata is reliable in the event.
+			// Re-fetch the full object to get current severity counts.
+			partial, ok := we.Object.(*unstructured.Unstructured)
 			if !ok {
+				continue
+			}
+			obj, err := c.client.Resource(gvr).Namespace(partial.GetNamespace()).Get(
+				ctx, partial.GetName(), metav1.GetOptions{},
+			)
+			if err != nil {
+				log.Printf("kubescape: get %s/%s: %v", partial.GetNamespace(), partial.GetName(), err)
 				continue
 			}
 			ev, fire := c.reconcile(obj, kind)
@@ -237,11 +241,12 @@ func (c *Collector) reconcile(obj *unstructured.Unstructured, kind string) (agen
 	container := labels[labelContainer]
 
 	// Count severity — use .relevant for vulns (eBPF runtime signal),
-	// direct count for config scans (no relevant/all split).
+	// falling back to .all when node-agent is not running (field absent).
+	// For config scans there is no all/relevant split.
 	var critCount, highCount int
 	if kind == "vulnerability" {
-		critCount = nestedInt(obj, "spec", "severities", "critical", "relevant")
-		highCount = nestedInt(obj, "spec", "severities", "high", "relevant")
+		critCount = relevantOrAll(obj, "critical")
+		highCount = relevantOrAll(obj, "high")
 	} else {
 		critCount = nestedInt(obj, "spec", "severities", "critical")
 		highCount = nestedInt(obj, "spec", "severities", "high")
@@ -280,6 +285,18 @@ func (c *Collector) reconcile(obj *unstructured.Unstructured, kind string) (agen
 		Container: container,
 		Labels:    labels,
 	}, true
+}
+
+// relevantOrAll returns the .relevant severity count for vulnerability summaries.
+// When node-agent (eBPF) is not running the .relevant field is absent entirely —
+// in that case it falls back to .all so findings are not silently dropped.
+// If .relevant exists and is 0 (eBPF confirmed no runtime exposure), 0 is returned.
+func relevantOrAll(obj *unstructured.Unstructured, sev string) int {
+	_, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "severities", sev, "relevant")
+	if found {
+		return nestedInt(obj, "spec", "severities", sev, "relevant")
+	}
+	return nestedInt(obj, "spec", "severities", sev, "all")
 }
 
 // nestedInt reads a numeric value from a nested path in an unstructured object.

--- a/cmd/agent/collectors/kubescape/collector_test.go
+++ b/cmd/agent/collectors/kubescape/collector_test.go
@@ -276,6 +276,33 @@ func TestReconcile_VulnUsesRelevantNotAll(t *testing.T) {
 	}
 }
 
+func TestReconcile_VulnFallsBackToAllWhenNoRelevant(t *testing.T) {
+	c := newTestCollector("high")
+	// No .relevant field at all — node-agent not running. Should fall back to .all.
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "scan-1", "namespace": "default", "generation": int64(1),
+				"annotations": map[string]interface{}{annotationStatus: statusCompleted},
+				"labels":      map[string]interface{}{labelNamespace: "default", labelKind: "Deployment", labelName: "vuln-test"},
+			},
+			"spec": map[string]interface{}{
+				"severities": map[string]interface{}{
+					"critical": map[string]interface{}{"all": int64(42)},
+					"high":     map[string]interface{}{"all": int64(218)},
+				},
+			},
+		},
+	}
+	ev, fire := c.reconcile(obj, "vulnerability")
+	if !fire {
+		t.Fatal("should fire when .relevant absent and .all > 0 (node-agent not running)")
+	}
+	if ev.Severity != "critical" {
+		t.Fatalf("want severity critical, got %s", ev.Severity)
+	}
+}
+
 func TestReconcile_ConfigCriticalFires(t *testing.T) {
 	c := newTestCollector("high")
 	obj := configScanSummary("scan-1", statusCompleted, 1, 2, 0)

--- a/docs/testing-wachd-agent.md
+++ b/docs/testing-wachd-agent.md
@@ -13,7 +13,7 @@ No real Kubernetes cluster required — everything runs in a kind cluster on you
 | kind | 0.24+ | `brew install kind` |
 | kubectl | 1.29+ | `brew install kubectl` |
 | Helm | 3.15+ | `brew install helm` |
-| Go | 1.25+ | https://go.dev/dl |
+| Go | 1.22+ | https://go.dev/dl |
 
 ---
 
@@ -145,9 +145,12 @@ Verify the agent is watching:
 ```bash
 kubectl -n wachd-agent logs -f deploy/wachd-agent
 # Should see:
-# kubescape: watching vulnerabilitymanifestsummaries in namespace kubescape
-# kubescape: watching workloadconfigurationscansummaries in namespace kubescape
+# kubescape: watching vulnerabilitymanifestsummaries across all namespaces (rv=)
+# kubescape: watching workloadconfigurationscansummaries across all namespaces (rv=)
 ```
+
+Note: `rv=` (empty) is expected — Kubescape uses a custom storage backend that does not
+return `metadata.resourceVersion` in list responses. The watch still receives events correctly.
 
 ---
 
@@ -167,27 +170,33 @@ kubectl scale deployment vuln-test --replicas=1 --namespace=default
 Trigger Kubescape to scan immediately (instead of waiting for the scheduled scan):
 
 ```bash
-# Annotate the namespace to trigger a scan
-kubectl annotate namespace default \
-  kubescape.io/scan=true --overwrite
+# Manually trigger kubevuln (vulnerability scanner) via a one-off job
+kubectl -n kubescape create job --from=cronjob/kubevuln-scheduler kubevuln-scan-now
 
-# Or use the Kubescape CLI if installed
-kubescape scan --submit --enable-host-scan
+# Wait for it to complete (~30s)
+kubectl -n kubescape wait --for=condition=complete job/kubevuln-scan-now --timeout=120s
 ```
 
-Watch for CRDs to appear:
+Note: `kubectl annotate namespace default kubescape.io/scan=true` does **not** trigger a scan
+in kind clusters — use the job approach above.
+
+Note: the `node-agent` pod will be in `CrashLoopBackOff` in kind — this is expected.
+Without node-agent (eBPF), `.relevant` severity counts are absent and the agent falls back
+to `.all` counts automatically.
+
+Watch for summaries to appear in the **workload namespace** (not the kubescape namespace):
 
 ```bash
-# In a new terminal — watch for summary objects
-kubectl get vulnerabilitymanifestsummaries -n kubescape -w
-kubectl get workloadconfigurationscansummaries -n kubescape -w
+# Summaries appear in the namespace of the scanned workload, not in the kubescape namespace
+kubectl get vulnerabilitymanifestsummaries -n default -w
+kubectl get workloadconfigurationscansummaries -n default -w
 ```
 
 ---
 
 ## 8. Verify an event was forwarded
 
-Once a summary object appears with `kubescape.io/status: completed`, the agent should forward it.
+Once a summary object appears with `kubescape.io/status: ready`, the agent should forward it.
 
 Check the agent logs:
 
@@ -209,10 +218,11 @@ Check the fake Wachd server (terminal from step 5):
 
 ## 9. Verify deduplication
 
-Trigger another scan of the same workload without changing anything:
+Bump the annotation on an existing summary (without changing findings) to trigger a re-reconcile:
 
 ```bash
-kubectl annotate namespace default kubescape.io/scan=true --overwrite
+kubectl annotate vulnerabilitymanifestsummary <name> -n default \
+  kubescape.io/bump="$(date +%s)" --overwrite
 ```
 
 The agent should **not** forward a second event for the same workload at the same finding count.
@@ -276,9 +286,9 @@ kind delete cluster --name wachd-agent-test
 
 **Agent not seeing scan results**
 
-Check that the summary objects have `kubescape.io/status: completed`:
+Check that the summary objects have `kubescape.io/status: ready`:
 ```bash
-kubectl get vulnerabilitymanifestsummaries -n kubescape -o json \
+kubectl get vulnerabilitymanifestsummaries -n default -o json \
   | jq '.items[].metadata.annotations["kubescape.io/status"]'
 ```
 
@@ -308,8 +318,10 @@ If connection refused: check your firewall allows port 8080 from the Docker brid
 
 This would mean the severity counts are always 0. Inspect a raw summary object:
 ```bash
-kubectl get vulnerabilitymanifestsummary <name> -n kubescape \
+kubectl get vulnerabilitymanifestsummary <name> -n default \
   -o jsonpath='{.spec.severities}'
 ```
 
-The `.relevant.critical` and `.relevant.high` fields should have non-zero values for old images with known CVEs.
+Summaries appear in the **workload namespace** (e.g. `default`), not in the `kubescape` namespace.
+In kind clusters without network access, the kubevuln scanner may return all-zero counts — this is
+a cluster limitation, not an agent bug. The agent correctly fires no event when counts are zero.


### PR DESCRIPTION
## Summary

Four bugs in `cmd/agent/collectors/kubescape/collector.go`, all found during local end-to-end testing against a kind cluster with Kubescape v1.40.2.

- **Wrong status value** — code checked `"completed"` but Kubescape uses `"ready"`, so no scans were ever processed
- **Wrong namespace** — agent watched only the `kubescape` namespace; summaries are written to the workload namespace (e.g. `default`). Switched to `Namespace("")` for cluster-wide watch
- **Missing `.relevant` fallback** — vulnerability counts used only `.relevant`, which is absent when node-agent (eBPF) is not running (kind clusters, clusters without the sensor). Added `relevantOrAll()` that falls back to `.all` when the field is absent
- **Incomplete watch event spec** — Kubescape's custom storage backend sends MODIFIED watch events with empty `spec.severities`. The agent re-fetches the full object via GET on each watch event to get current counts

Also fixes `docs/testing-wachd-agent.md`: wrong Go version (1.25→1.22), wrong scan trigger command (annotation approach doesn't work — use `kubectl create job`), wrong namespace for summaries, wrong status value, and adds notes on kind-specific limitations.

## Test plan

- [x] All 40 unit tests pass (`go test ./cmd/agent/... -race`)
- [x] kind cluster: agent watches all namespaces, primes state on startup
- [x] Real scanner data (nginx:1.19.0 → crit=42, high=218) triggers forward
- [x] Forward reaches real Wachd server → incident created with `source: "kubescape"`
- [x] Claude AI analysis runs → correctly identifies 260 CVEs in outdated nginx image, suggests image replacement + CI/CD scanning gate (confidence: high)
- [x] Dedup: second event with same counts → silent
- [x] `minSeverity=critical`: high-only findings filtered, critical fires
- [x] RBAC: SA can get/list/watch Kubescape CRDs, cannot access pods/secrets

Closes #67