### PR TITLE
fix(server): incident dedup and resolve via fingerprint

### DIFF
--- a/cmd/server/e2e_integration_test.go
+++ b/cmd/server/e2e_integration_test.go
@@ -43,6 +43,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -62,6 +63,8 @@ import (
 type e2eEnv struct {
 	db                  *store.DB
 	router              *mux.Router
+	server              *Server
+	q                   *queue.Queue
 	kongTeam            *store.Team
 	kafkaTeam           *store.Team
 	kongCookie          *http.Cookie // admin session scoped to Kong team only
@@ -186,6 +189,8 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	return &e2eEnv{
 		db:                  db,
 		router:              router,
+		server:              server,
+		q:                   q,
 		kongTeam:            kongTeam,
 		kafkaTeam:           kafkaTeam,
 		kongCookie:          kongCookie,
@@ -982,4 +987,240 @@ func TestE2E_ServiceDependencies_FilterByService(t *testing.T) {
 	if len(redisDeps) != 0 {
 		t.Errorf("filter by depends_on value should return 0 results, got %d", len(redisDeps))
 	}
+}
+
+// ── webhook dedup / fingerprint tests ─────────────────────────────────────────
+
+// fireAgentWebhook POSTs a generic agent-style payload (explicit "source" field)
+// to the given team's webhook. Returns the HTTP status code and decoded body.
+// Pass status="resolved" to fire a resolved event.
+func fireAgentWebhook(t *testing.T, e *e2eEnv, team *store.Team, title, source, status string) (int, map[string]any) {
+	t.Helper()
+	payload := map[string]any{
+		"title":    title,
+		"source":   source,
+		"severity": "high",
+	}
+	if status != "" {
+		payload["status"] = status
+	}
+	body := e2eBody(t, payload)
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/webhook/%s/%s", team.ID, team.WebhookSecret),
+		body)
+	req.Header.Set("Content-Type", "application/json")
+	resp := e.do(req)
+	var result map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	return resp.Code, result
+}
+
+// countIncidentsByTitle counts DB rows for a team matching the given title.
+// Used to verify no duplicate incidents were created.
+func countIncidentsByTitle(t *testing.T, e *e2eEnv, teamID, title string) int {
+	t.Helper()
+	var n int
+	err := e.db.Pool().QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM incidents WHERE team_id = $1 AND title = $2`,
+		teamID, title).Scan(&n)
+	if err != nil {
+		t.Fatalf("countIncidentsByTitle: %v", err)
+	}
+	return n
+}
+
+// TestWebhookDedup covers the five receiver-level dedup correctness cases that
+// the unit tests in webhook_parser_test.go cannot reach.
+func TestWebhookDedup(t *testing.T) {
+	env := newE2EEnv(t)
+	team := env.kongTeam
+
+	t.Run("first_fire_creates_incident_with_fingerprint", func(t *testing.T) {
+		title := fmt.Sprintf("dedup-test-first-%d", time.Now().UnixNano())
+		code, body := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+
+		if code != http.StatusAccepted {
+			t.Fatalf("want 202, got %d: %v", code, body)
+		}
+		if body["status"] != "accepted" {
+			t.Errorf("want status=accepted, got %q", body["status"])
+		}
+		incidentID, ok := body["incident_id"].(string)
+		if !ok || incidentID == "" {
+			t.Fatal("incident_id missing from response")
+		}
+
+		// Verify fingerprint was stored in DB.
+		var fp *string
+		err := env.db.Pool().QueryRow(context.Background(),
+			`SELECT fingerprint FROM incidents WHERE id = $1 AND team_id = $2`,
+			incidentID, team.ID.String()).Scan(&fp)
+		if err != nil {
+			t.Fatalf("fingerprint lookup: %v", err)
+		}
+		if fp == nil || *fp == "" {
+			t.Error("fingerprint should be non-empty after first fire")
+		}
+		if len(*fp) != 64 {
+			t.Errorf("fingerprint should be 64 hex chars, got %d", len(*fp))
+		}
+	})
+
+	t.Run("duplicate_returns_deduplicated_no_second_row", func(t *testing.T) {
+		title := fmt.Sprintf("dedup-test-dup-%d", time.Now().UnixNano())
+
+		code1, body1 := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+		if code1 != http.StatusAccepted || body1["status"] != "accepted" {
+			t.Fatalf("first fire: want 202/accepted, got %d/%v", code1, body1["status"])
+		}
+		id1 := body1["incident_id"].(string)
+
+		code2, body2 := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+		if code2 != http.StatusAccepted {
+			t.Fatalf("duplicate: want 202, got %d: %v", code2, body2)
+		}
+		if body2["status"] != "deduplicated" {
+			t.Errorf("duplicate: want status=deduplicated, got %q", body2["status"])
+		}
+		if body2["incident_id"] != id1 {
+			t.Errorf("duplicate: want same incident_id %q, got %q", id1, body2["incident_id"])
+		}
+
+		// Exactly one row in DB for this title.
+		if n := countIncidentsByTitle(t, env, team.ID.String(), title); n != 1 {
+			t.Errorf("want 1 incident row, got %d", n)
+		}
+	})
+
+	t.Run("resolve_closes_incident_no_new_row", func(t *testing.T) {
+		title := fmt.Sprintf("dedup-test-resolve-%d", time.Now().UnixNano())
+
+		// Fire alert.
+		code, body := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+		if code != http.StatusAccepted || body["status"] != "accepted" {
+			t.Fatalf("fire: want 202/accepted, got %d/%v", code, body["status"])
+		}
+		incidentID := body["incident_id"].(string)
+
+		// Fire resolved event.
+		rcode, rbody := fireAgentWebhook(t, env, team, title, "k8shealth", "resolved")
+		if rcode != http.StatusAccepted {
+			t.Fatalf("resolve: want 202, got %d: %v", rcode, rbody)
+		}
+		if rbody["status"] != "resolved" {
+			t.Errorf("resolve: want status=resolved, got %q", rbody["status"])
+		}
+
+		// Incident should be closed in DB.
+		var status string
+		err := env.db.Pool().QueryRow(context.Background(),
+			`SELECT status FROM incidents WHERE id = $1 AND team_id = $2`,
+			incidentID, team.ID.String()).Scan(&status)
+		if err != nil {
+			t.Fatalf("status lookup: %v", err)
+		}
+		if status != "resolved" {
+			t.Errorf("want status=resolved in DB, got %q", status)
+		}
+
+		// Still exactly one row — no new low-severity incident was created.
+		if n := countIncidentsByTitle(t, env, team.ID.String(), title); n != 1 {
+			t.Errorf("want 1 incident row after resolve, got %d", n)
+		}
+	})
+
+	t.Run("resolve_works_at_quota_limit", func(t *testing.T) {
+		title := fmt.Sprintf("dedup-test-quota-%d", time.Now().UnixNano())
+
+		// Fire alert via normal env to create an open incident.
+		code, body := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+		if code != http.StatusAccepted || body["status"] != "accepted" {
+			t.Fatalf("fire: want 202/accepted, got %d/%v", code, body["status"])
+		}
+		incidentID := body["incident_id"].(string)
+
+		// Build a server with MaxAlertsMonth = 0 so every new-create attempt is
+		// blocked, but resolve/dedup paths (which run before the quota check) are not.
+		limitedSrv := &Server{
+			cfg:   env.db,
+			db:    env.db,
+			queue: env.q,
+			license: &license.License{
+				Tier:           license.TierOpenSource,
+				MaxAlertsMonth: 0,
+			},
+			webhookLimiter: newWebhookIPLimiter(),
+		}
+		limitedRouter := mux.NewRouter()
+		limitedRouter.HandleFunc("/api/v1/webhook/{teamId}/{secret}",
+			limitedSrv.handleWebhook).Methods("POST")
+		limitedEnv := &e2eEnv{db: env.db, router: limitedRouter}
+
+		// A new firing alert should be blocked (quota exhausted).
+		other := fmt.Sprintf("dedup-test-quota-new-%d", time.Now().UnixNano())
+		ncode, _ := fireAgentWebhook(t, limitedEnv, team, other, "k8shealth", "")
+		if ncode != http.StatusTooManyRequests {
+			t.Errorf("new alert at quota limit: want 429, got %d", ncode)
+		}
+
+		// Resolve for existing incident must still succeed.
+		rcode, rbody := fireAgentWebhook(t, limitedEnv, team, title, "k8shealth", "resolved")
+		if rcode != http.StatusAccepted {
+			t.Fatalf("resolve at quota limit: want 202, got %d: %v", rcode, rbody)
+		}
+		if rbody["status"] != "resolved" {
+			t.Errorf("resolve at quota limit: want status=resolved, got %q", rbody["status"])
+		}
+
+		// Incident closed in DB.
+		var dbStatus string
+		err := env.db.Pool().QueryRow(context.Background(),
+			`SELECT status FROM incidents WHERE id = $1 AND team_id = $2`,
+			incidentID, team.ID.String()).Scan(&dbStatus)
+		if err != nil {
+			t.Fatalf("status lookup: %v", err)
+		}
+		if dbStatus != "resolved" {
+			t.Errorf("want status=resolved in DB, got %q", dbStatus)
+		}
+	})
+
+	t.Run("concurrent_duplicates_create_one_incident", func(t *testing.T) {
+		title := fmt.Sprintf("dedup-test-concurrent-%d", time.Now().UnixNano())
+		const workers = 10
+
+		type result struct {
+			code int
+			body map[string]any
+		}
+		results := make([]result, workers)
+
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		// Start all goroutines simultaneously using a shared gate.
+		gate := make(chan struct{})
+		for i := 0; i < workers; i++ {
+			i := i
+			go func() {
+				defer wg.Done()
+				<-gate
+				code, body := fireAgentWebhook(t, env, team, title, "k8shealth", "")
+				results[i] = result{code, body}
+			}()
+		}
+		close(gate) // release all goroutines at once
+		wg.Wait()
+
+		// Every response must be 202 (accepted or deduplicated).
+		for i, r := range results {
+			if r.code != http.StatusAccepted {
+				t.Errorf("worker %d: want 202, got %d", i, r.code)
+			}
+		}
+
+		// Exactly one row in DB for this title.
+		if n := countIncidentsByTitle(t, env, team.ID.String(), title); n != 1 {
+			t.Errorf("concurrent inserts: want 1 incident row, got %d", n)
+		}
+	})
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -241,7 +241,8 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string, 
 	var dd DatadogWebhook
 	if err := json.Unmarshal(body, &dd); err == nil && (dd.AlertID != 0 || dd.AlertTransition != "") {
 		sev := "unknown"
-		switch dd.AlertType {
+		alertType := strings.ToLower(strings.TrimSpace(dd.AlertType))
+		switch alertType {
 		case "error":
 			sev = "critical"
 		case "warning":
@@ -259,7 +260,7 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string, 
 		if t == "" {
 			t = "Datadog alert"
 		}
-		return t, msg, sev, "datadog", dd.AlertType == "success"
+		return t, msg, sev, "datadog", alertType == "success"
 	}
 
 	// Generic fallback — handles wachd-agent payloads and any source that sets
@@ -281,7 +282,7 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string, 
 				sev = "unknown"
 			}
 			status, _ := raw["status"].(string)
-			return t, msg, sev, src, status == "resolved"
+			return t, msg, sev, src, strings.ToLower(strings.TrimSpace(status)) == "resolved"
 		}
 	}
 
@@ -292,14 +293,15 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string, 
 		if t == "" {
 			t = gf.RuleName
 		}
+		state := strings.ToLower(strings.TrimSpace(gf.State))
 		sev := "unknown"
-		switch gf.State {
+		switch state {
 		case "alerting":
 			sev = "high"
 		case "ok":
 			sev = "low"
 		}
-		return t, gf.Message, sev, "grafana", gf.State == "ok"
+		return t, gf.Message, sev, "grafana", state == "ok"
 	}
 
 	// Generic fallback — extract title/message from any JSON payload
@@ -766,7 +768,62 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce license monthly alert limit.
+	// Read webhook payload — limit to 1 MB to prevent memory exhaustion.
+	// Done before quota check so resolved/dedup webhooks are never blocked by the limit.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	// Parse webhook — auto-detects Grafana, Datadog, or generic format
+	title, message, severity, source, resolved := parseWebhookPayload(body)
+
+	fingerprint := incidentFingerprint(teamID, source, title)
+
+	// Resolve path — find and close the matching open incident, no new row created.
+	// Runs before quota check: a resolved webhook must always be able to close an
+	// existing incident, even when the team has hit their monthly create limit.
+	if resolved {
+		existing, _ := s.db.FindOpenIncidentByFingerprint(r.Context(), teamID, fingerprint)
+		if err := s.db.ResolveIncidentByFingerprint(r.Context(), teamID, fingerprint); err != nil {
+			log.Printf("warn: resolve by fingerprint team %s: %v", teamID, err)
+		} else {
+			log.Printf("→ resolved [%s] %s (team %s)", source, title, teamID)
+			if existing != nil {
+				if err := s.queue.EnqueueIncidentResolved(r.Context(), existing.ID, teamID); err != nil {
+					log.Printf("warn: enqueue resolved job for %s: %v", existing.ID, err)
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "resolved"})
+		return
+	}
+
+	// Dedup — if an open/acknowledged/snoozed incident with this fingerprint
+	// already exists, skip creating a duplicate.
+	// Runs before quota check: a duplicate webhook must not consume a quota slot.
+	existing, err := s.db.FindOpenIncidentByFingerprint(r.Context(), teamID, fingerprint)
+	if err != nil {
+		log.Printf("warn: fingerprint lookup team %s: %v", teamID, err)
+		// fail open — proceed to create so we never silently drop an alert
+	}
+	if existing != nil {
+		log.Printf("→ dedup [%s/%s] %s (open: %s)", source, severity, title, existing.ID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":      "deduplicated",
+			"incident_id": existing.ID,
+		})
+		return
+	}
+
+	// Enforce license monthly alert limit — only reached when creating a new incident.
 	alertCount, err := s.db.CountIncidentsThisMonth(r.Context())
 	if err != nil {
 		log.Printf("handleWebhook: count incidents: %v", err)
@@ -787,51 +844,6 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read webhook payload — limit to 1 MB to prevent memory exhaustion.
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Failed to read body", http.StatusBadRequest)
-		return
-	}
-	defer func() { _ = r.Body.Close() }()
-
-	// Parse webhook — auto-detects Grafana, Datadog, or generic format
-	title, message, severity, source, resolved := parseWebhookPayload(body)
-
-	fingerprint := incidentFingerprint(teamID, source, title)
-
-	// Resolve path — find and close the matching open incident, no new row created.
-	if resolved {
-		if err := s.db.ResolveIncidentByFingerprint(r.Context(), teamID, fingerprint); err != nil {
-			log.Printf("warn: resolve by fingerprint team %s: %v", teamID, err)
-		} else {
-			log.Printf("→ resolved [%s] %s (team %s)", source, title, teamID)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "resolved"})
-		return
-	}
-
-	// Dedup — if an open/acknowledged/snoozed incident with this fingerprint
-	// already exists, skip creating a duplicate.
-	existing, err := s.db.FindOpenIncidentByFingerprint(r.Context(), teamID, fingerprint)
-	if err != nil {
-		log.Printf("warn: fingerprint lookup team %s: %v", teamID, err)
-		// fail open — proceed to create so we never silently drop an alert
-	}
-	if existing != nil {
-		log.Printf("→ dedup [%s/%s] %s (open: %s)", source, severity, title, existing.ID)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"status":      "deduplicated",
-			"incident_id": existing.ID,
-		})
-		return
-	}
-
 	fp := fingerprint
 
 	// Create incident
@@ -847,6 +859,17 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.db.CreateIncident(r.Context(), incident); err != nil {
+		if errors.Is(err, store.ErrDuplicateIncident) {
+			// Concurrent duplicate slipped past the application-level dedup and hit
+			// the unique partial index. Look up the winner and return deduplicated.
+			if winner, lookupErr := s.db.FindOpenIncidentByFingerprint(r.Context(), teamID, fingerprint); lookupErr == nil && winner != nil {
+				log.Printf("→ dedup (race) [%s] %s (open: %s)", source, title, winner.ID)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "deduplicated", "incident_id": winner.ID})
+				return
+			}
+		}
 		log.Printf("Failed to create incident: %v", err)
 		http.Error(w, "Failed to create incident", http.StatusInternalServerError)
 		return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -727,7 +727,7 @@ func writeForbidden(w http.ResponseWriter) {
 // Used to deduplicate firing alerts and match resolved events to open incidents.
 func incidentFingerprint(teamID uuid.UUID, source, title string) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "%s|%s|%s", teamID.String(), source, strings.ToLower(strings.TrimSpace(title)))
+	_, _ = fmt.Fprintf(h, "%s|%s|%s", teamID.String(), source, strings.ToLower(strings.TrimSpace(title)))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -235,7 +236,7 @@ type DatadogWebhook struct {
 // parseWebhookPayload detects the source format and extracts a normalised
 // (title, message, severity, source) tuple. Unknown payloads fall back to a
 // generic extraction using the raw JSON keys "title" and "message".
-func parseWebhookPayload(body []byte) (title, message, severity, source string) {
+func parseWebhookPayload(body []byte) (title, message, severity, source string, resolved bool) {
 	// Try to detect Datadog: it always has alert_id (int) or alert_transition field.
 	var dd DatadogWebhook
 	if err := json.Unmarshal(body, &dd); err == nil && (dd.AlertID != 0 || dd.AlertTransition != "") {
@@ -258,7 +259,7 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string) 
 		if t == "" {
 			t = "Datadog alert"
 		}
-		return t, msg, sev, "datadog"
+		return t, msg, sev, "datadog", dd.AlertType == "success"
 	}
 
 	// Generic fallback — handles wachd-agent payloads and any source that sets
@@ -279,7 +280,8 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string) 
 			if sev == "" {
 				sev = "unknown"
 			}
-			return t, msg, sev, src
+			status, _ := raw["status"].(string)
+			return t, msg, sev, src, status == "resolved"
 		}
 	}
 
@@ -297,7 +299,7 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string) 
 		case "ok":
 			sev = "low"
 		}
-		return t, gf.Message, sev, "grafana"
+		return t, gf.Message, sev, "grafana", gf.State == "ok"
 	}
 
 	// Generic fallback — extract title/message from any JSON payload
@@ -317,10 +319,10 @@ func parseWebhookPayload(body []byte) (title, message, severity, source string) 
 		if sev == "" {
 			sev = "unknown"
 		}
-		return t, msg, sev, "generic"
+		return t, msg, sev, "generic", false
 	}
 
-	return "Alert", "", "unknown", "generic"
+	return "Alert", "", "unknown", "generic", false
 }
 
 func main() {
@@ -721,6 +723,14 @@ func writeForbidden(w http.ResponseWriter) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": "forbidden"})
 }
 
+// incidentFingerprint returns a SHA-256 hex digest of team+source+title.
+// Used to deduplicate firing alerts and match resolved events to open incidents.
+func incidentFingerprint(teamID uuid.UUID, source, title string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%s", teamID.String(), source, strings.ToLower(strings.TrimSpace(title)))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
 func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	teamIDStr := vars["teamId"]
@@ -787,7 +797,42 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	// Parse webhook — auto-detects Grafana, Datadog, or generic format
-	title, message, severity, source := parseWebhookPayload(body)
+	title, message, severity, source, resolved := parseWebhookPayload(body)
+
+	fingerprint := incidentFingerprint(teamID, source, title)
+
+	// Resolve path — find and close the matching open incident, no new row created.
+	if resolved {
+		if err := s.db.ResolveIncidentByFingerprint(r.Context(), teamID, fingerprint); err != nil {
+			log.Printf("warn: resolve by fingerprint team %s: %v", teamID, err)
+		} else {
+			log.Printf("→ resolved [%s] %s (team %s)", source, title, teamID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "resolved"})
+		return
+	}
+
+	// Dedup — if an open/acknowledged/snoozed incident with this fingerprint
+	// already exists, skip creating a duplicate.
+	existing, err := s.db.FindOpenIncidentByFingerprint(r.Context(), teamID, fingerprint)
+	if err != nil {
+		log.Printf("warn: fingerprint lookup team %s: %v", teamID, err)
+		// fail open — proceed to create so we never silently drop an alert
+	}
+	if existing != nil {
+		log.Printf("→ dedup [%s/%s] %s (open: %s)", source, severity, title, existing.ID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":      "deduplicated",
+			"incident_id": existing.ID,
+		})
+		return
+	}
+
+	fp := fingerprint
 
 	// Create incident
 	incident := &store.Incident{
@@ -798,6 +843,7 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		Status:       "open",
 		Source:       source,
 		AlertPayload: body,
+		Fingerprint:  &fp,
 	}
 
 	if err := s.db.CreateIncident(r.Context(), incident); err != nil {

--- a/cmd/server/webhook_parser_test.go
+++ b/cmd/server/webhook_parser_test.go
@@ -17,6 +17,8 @@ package main
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestParseWebhookPayload_AgentKubescape(t *testing.T) {
@@ -31,7 +33,7 @@ func TestParseWebhookPayload_AgentKubescape(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	title, message, severity, source := parseWebhookPayload(body)
+	title, message, severity, source, resolved := parseWebhookPayload(body)
 
 	if source != "kubescape" {
 		t.Errorf("source: want kubescape, got %q", source)
@@ -45,6 +47,9 @@ func TestParseWebhookPayload_AgentKubescape(t *testing.T) {
 	if message != "3 critical CVEs in runtime packages" {
 		t.Errorf("message mismatch: %q", message)
 	}
+	if resolved {
+		t.Error("resolved: want false for a firing alert")
+	}
 }
 
 func TestParseWebhookPayload_AgentHighSeverity(t *testing.T) {
@@ -55,13 +60,16 @@ func TestParseWebhookPayload_AgentHighSeverity(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	_, _, severity, source := parseWebhookPayload(body)
+	_, _, severity, source, resolved := parseWebhookPayload(body)
 
 	if source != "kubescape" {
 		t.Errorf("source: want kubescape, got %q", source)
 	}
 	if severity != "high" {
 		t.Errorf("severity: want high, got %q", severity)
+	}
+	if resolved {
+		t.Error("resolved: want false for a firing alert")
 	}
 }
 
@@ -74,7 +82,7 @@ func TestParseWebhookPayload_GrafanaStillWorks(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	_, _, severity, source := parseWebhookPayload(body)
+	_, _, severity, source, resolved := parseWebhookPayload(body)
 
 	if source != "grafana" {
 		t.Errorf("source: want grafana, got %q", source)
@@ -82,24 +90,30 @@ func TestParseWebhookPayload_GrafanaStillWorks(t *testing.T) {
 	if severity != "high" {
 		t.Errorf("severity: want high for alerting state, got %q", severity)
 	}
+	if resolved {
+		t.Error("resolved: want false for alerting state")
+	}
 }
 
 func TestParseWebhookPayload_DatadogStillWorks(t *testing.T) {
 	payload := map[string]interface{}{
-		"title":             "Service latency spike",
-		"alert_type":        "error",
-		"alert_transition":  "Triggered",
-		"alert_id":          int64(12345),
+		"title":            "Service latency spike",
+		"alert_type":       "error",
+		"alert_transition": "Triggered",
+		"alert_id":         int64(12345),
 	}
 	body, _ := json.Marshal(payload)
 
-	_, _, severity, source := parseWebhookPayload(body)
+	_, _, severity, source, resolved := parseWebhookPayload(body)
 
 	if source != "datadog" {
 		t.Errorf("source: want datadog, got %q", source)
 	}
 	if severity != "critical" {
 		t.Errorf("severity: want critical for alert_type=error, got %q", severity)
+	}
+	if resolved {
+		t.Error("resolved: want false for alert_type=error")
 	}
 }
 
@@ -112,7 +126,7 @@ func TestParseWebhookPayload_GenericNoSource(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	title, _, severity, source := parseWebhookPayload(body)
+	title, _, severity, source, resolved := parseWebhookPayload(body)
 
 	if source != "generic" {
 		t.Errorf("source: want generic, got %q", source)
@@ -122,6 +136,9 @@ func TestParseWebhookPayload_GenericNoSource(t *testing.T) {
 	}
 	if title != "Something happened" {
 		t.Errorf("title: want 'Something happened', got %q", title)
+	}
+	if resolved {
+		t.Error("resolved: want false for generic payload")
 	}
 }
 
@@ -134,9 +151,112 @@ func TestParseWebhookPayload_EmptySourceFallsThrough(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	_, _, _, source := parseWebhookPayload(body)
+	_, _, _, source, _ := parseWebhookPayload(body)
 
 	if source != "grafana" {
 		t.Errorf("empty source should fall through to grafana detection, got %q", source)
+	}
+}
+
+func TestParseWebhookPayload_GrafanaResolvedReturnsTrue(t *testing.T) {
+	payload := map[string]interface{}{
+		"title": "CPU above threshold",
+		"state": "ok",
+	}
+	body, _ := json.Marshal(payload)
+
+	_, _, _, source, resolved := parseWebhookPayload(body)
+
+	if source != "grafana" {
+		t.Errorf("source: want grafana, got %q", source)
+	}
+	if !resolved {
+		t.Error("resolved: want true for state=ok")
+	}
+}
+
+func TestParseWebhookPayload_AgentResolvedReturnsTrue(t *testing.T) {
+	payload := map[string]interface{}{
+		"title":    "CrashLoopBackOff: payments-api/pod-xyz",
+		"severity": "high",
+		"source":   "k8shealth",
+		"status":   "resolved",
+	}
+	body, _ := json.Marshal(payload)
+
+	_, _, _, source, resolved := parseWebhookPayload(body)
+
+	if source != "k8shealth" {
+		t.Errorf("source: want k8shealth, got %q", source)
+	}
+	if !resolved {
+		t.Error("resolved: want true for status=resolved")
+	}
+}
+
+func TestParseWebhookPayload_DatadogResolvedReturnsTrue(t *testing.T) {
+	payload := map[string]interface{}{
+		"title":            "Service latency spike",
+		"alert_type":       "success",
+		"alert_transition": "Recovered",
+		"alert_id":         int64(12345),
+	}
+	body, _ := json.Marshal(payload)
+
+	_, _, _, source, resolved := parseWebhookPayload(body)
+
+	if source != "datadog" {
+		t.Errorf("source: want datadog, got %q", source)
+	}
+	if !resolved {
+		t.Error("resolved: want true for alert_type=success")
+	}
+}
+
+func TestIncidentFingerprint_Deterministic(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	a := incidentFingerprint(id, "grafana", "CPU above threshold")
+	b := incidentFingerprint(id, "grafana", "CPU above threshold")
+
+	if a != b {
+		t.Errorf("fingerprint not deterministic: %q != %q", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("expected 64-char SHA-256 hex, got len %d: %q", len(a), a)
+	}
+}
+
+func TestIncidentFingerprint_NormalizesTitle(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	a := incidentFingerprint(id, "grafana", "CPU Above Threshold")
+	b := incidentFingerprint(id, "grafana", "  cpu above threshold  ")
+
+	if a != b {
+		t.Errorf("fingerprint should normalize title case and whitespace: %q != %q", a, b)
+	}
+}
+
+func TestIncidentFingerprint_DifferentTeamsDiffer(t *testing.T) {
+	id1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	id2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	a := incidentFingerprint(id1, "grafana", "CPU above threshold")
+	b := incidentFingerprint(id2, "grafana", "CPU above threshold")
+
+	if a == b {
+		t.Error("fingerprints for different teams must differ")
+	}
+}
+
+func TestIncidentFingerprint_DifferentSourcesDiffer(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	a := incidentFingerprint(id, "grafana", "CPU above threshold")
+	b := incidentFingerprint(id, "datadog", "CPU above threshold")
+
+	if a == b {
+		t.Error("fingerprints for different sources must differ")
 	}
 }

--- a/internal/store/incidents.go
+++ b/internal/store/incidents.go
@@ -29,9 +29,9 @@ func (db *DB) CreateIncident(ctx context.Context, incident *Incident) error {
 	query := `
 		INSERT INTO incidents (
 			id, team_id, title, message, severity, status, source,
-			alert_payload, fired_at, created_at, updated_at
+			alert_payload, fingerprint, fired_at, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 		)
 	`
 
@@ -53,6 +53,7 @@ func (db *DB) CreateIncident(ctx context.Context, incident *Incident) error {
 		incident.Status,
 		incident.Source,
 		incident.AlertPayload,
+		incident.Fingerprint,
 		incident.FiredAt,
 		incident.CreatedAt,
 		incident.UpdatedAt,
@@ -359,4 +360,66 @@ func (db *DB) IncrementEscalationStep(ctx context.Context, teamID, incidentID uu
 		return false, fmt.Errorf("failed to increment escalation step: %w", err)
 	}
 	return res.RowsAffected() == 1, nil
+}
+
+// FindOpenIncidentByFingerprint returns the most recently fired open, acknowledged,
+// or snoozed incident with the given fingerprint for a team.
+// Returns nil (no error) when no matching incident exists.
+func (db *DB) FindOpenIncidentByFingerprint(ctx context.Context, teamID uuid.UUID, fingerprint string) (*Incident, error) {
+	query := `
+		SELECT
+			id, team_id, title, message, severity, status, source,
+			alert_payload, context, analysis,
+			fired_at, acknowledged_at, resolved_at, snoozed_until,
+			escalation_step, created_at, updated_at, assigned_to
+		FROM incidents
+		WHERE team_id = $1 AND fingerprint = $2
+		  AND status IN ('open', 'acknowledged', 'snoozed')
+		ORDER BY fired_at DESC
+		LIMIT 1
+	`
+	incident := &Incident{}
+	err := db.pool.QueryRow(ctx, query, teamID, fingerprint).Scan(
+		&incident.ID,
+		&incident.TeamID,
+		&incident.Title,
+		&incident.Message,
+		&incident.Severity,
+		&incident.Status,
+		&incident.Source,
+		&incident.AlertPayload,
+		&incident.Context,
+		&incident.Analysis,
+		&incident.FiredAt,
+		&incident.AcknowledgedAt,
+		&incident.ResolvedAt,
+		&incident.SnoozedUntil,
+		&incident.EscalationStep,
+		&incident.CreatedAt,
+		&incident.UpdatedAt,
+		&incident.AssignedTo,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find open incident by fingerprint: %w", err)
+	}
+	return incident, nil
+}
+
+// ResolveIncidentByFingerprint closes any open, acknowledged, or snoozed incident
+// matching the given fingerprint for a team. No-ops silently when no match exists.
+func (db *DB) ResolveIncidentByFingerprint(ctx context.Context, teamID uuid.UUID, fingerprint string) error {
+	now := time.Now().UTC()
+	_, err := db.pool.Exec(ctx, `
+		UPDATE incidents
+		SET status = 'resolved', resolved_at = $1, updated_at = $1
+		WHERE team_id = $2 AND fingerprint = $3
+		  AND status IN ('open', 'acknowledged', 'snoozed')
+	`, now, teamID, fingerprint)
+	if err != nil {
+		return fmt.Errorf("resolve incident by fingerprint: %w", err)
+	}
+	return nil
 }

--- a/internal/store/incidents.go
+++ b/internal/store/incidents.go
@@ -17,12 +17,19 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// ErrDuplicateIncident is returned by CreateIncident when a concurrent insert
+// races past the application-level dedup and hits the unique partial index.
+// Callers should treat this as a deduplicated response, not a hard failure.
+var ErrDuplicateIncident = errors.New("duplicate active incident")
 
 // CreateIncident creates a new incident in the database
 func (db *DB) CreateIncident(ctx context.Context, incident *Incident) error {
@@ -60,6 +67,10 @@ func (db *DB) CreateIncident(ctx context.Context, incident *Incident) error {
 	)
 
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDuplicateIncident
+		}
 		return fmt.Errorf("failed to create incident: %w", err)
 	}
 

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -119,14 +119,14 @@ type ServiceDependency struct {
 
 // SSOIdentity is a provider-level identity (one per person, not per team)
 type SSOIdentity struct {
-	ID         uuid.UUID  `json:"id"`
-	Provider   string     `json:"provider"`    // entra | google | okta
-	ProviderID string     `json:"provider_id"` // oid claim
-	Email      string     `json:"email"`
-	Name       string     `json:"name"`
-	AvatarURL  *string    `json:"avatar_url,omitempty"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID         uuid.UUID `json:"id"`
+	Provider   string    `json:"provider"`    // entra | google | okta
+	ProviderID string    `json:"provider_id"` // oid claim
+	Email      string    `json:"email"`
+	Name       string    `json:"name"`
+	AvatarURL  *string   `json:"avatar_url,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // TeamAccess links an SSO identity to a team with a role
@@ -151,22 +151,22 @@ type GroupMapping struct {
 
 // TeamConfig represents team-specific configuration
 type TeamConfig struct {
-	TeamID                uuid.UUID  `json:"team_id"`
-	SlackWebhookURL       *string    `json:"slack_webhook_url,omitempty"`
-	SlackChannel          *string    `json:"slack_channel,omitempty"`
-	SlackBotToken         *string    `json:"slack_bot_token,omitempty"`
-	GitHubTokenEncrypted  *string    `json:"github_token_encrypted,omitempty"`
-	GitHubRepos           []byte     `json:"github_repos,omitempty"` // JSONB
-	GrafanaMCPURL         *string    `json:"grafana_mcp_url,omitempty"`
-	GrafanaMCPTokenEncrypted *string `json:"grafana_mcp_token_encrypted,omitempty"`
-	PrometheusEndpoint          *string    `json:"prometheus_endpoint,omitempty"`
-	LokiEndpoint                *string    `json:"loki_endpoint,omitempty"`
-	DynatraceEndpoint           *string    `json:"dynatrace_endpoint,omitempty"`
-	DynatraceTokenEncrypted     *string    `json:"dynatrace_token_encrypted,omitempty"`
-	SplunkEndpoint              *string    `json:"splunk_endpoint,omitempty"`
-	SplunkTokenEncrypted        *string    `json:"splunk_token_encrypted,omitempty"`
-	CreatedAt             time.Time  `json:"created_at"`
-	UpdatedAt             time.Time  `json:"updated_at"`
+	TeamID                   uuid.UUID `json:"team_id"`
+	SlackWebhookURL          *string   `json:"slack_webhook_url,omitempty"`
+	SlackChannel             *string   `json:"slack_channel,omitempty"`
+	SlackBotToken            *string   `json:"slack_bot_token,omitempty"`
+	GitHubTokenEncrypted     *string   `json:"github_token_encrypted,omitempty"`
+	GitHubRepos              []byte    `json:"github_repos,omitempty"` // JSONB
+	GrafanaMCPURL            *string   `json:"grafana_mcp_url,omitempty"`
+	GrafanaMCPTokenEncrypted *string   `json:"grafana_mcp_token_encrypted,omitempty"`
+	PrometheusEndpoint       *string   `json:"prometheus_endpoint,omitempty"`
+	LokiEndpoint             *string   `json:"loki_endpoint,omitempty"`
+	DynatraceEndpoint        *string   `json:"dynatrace_endpoint,omitempty"`
+	DynatraceTokenEncrypted  *string   `json:"dynatrace_token_encrypted,omitempty"`
+	SplunkEndpoint           *string   `json:"splunk_endpoint,omitempty"`
+	SplunkTokenEncrypted     *string   `json:"splunk_token_encrypted,omitempty"`
+	CreatedAt                time.Time `json:"created_at"`
+	UpdatedAt                time.Time `json:"updated_at"`
 }
 
 // SystemConfig holds platform-wide settings managed by the superadmin only.
@@ -195,20 +195,20 @@ type TeamMember struct {
 
 // LocalUser is a non-SSO auth identity (includes bootstrap admin).
 type LocalUser struct {
-	ID                   uuid.UUID  `json:"id"`
-	Username             string     `json:"username"`
-	Email                string     `json:"email"`
-	Name                 string     `json:"name"`
-	Phone                *string    `json:"phone,omitempty"`
-	PasswordHash         string     `json:"-"` // never serialized
-	IsSuperAdmin         bool       `json:"is_superadmin"`
-	IsActive             bool       `json:"is_active"`
-	ForcePasswordChange  bool       `json:"force_password_change"`
-	FailedLoginAttempts  int        `json:"failed_login_attempts"`
-	LockedUntil          *time.Time `json:"locked_until,omitempty"`
-	LastLoginAt          *time.Time `json:"last_login_at,omitempty"`
-	CreatedAt            time.Time  `json:"created_at"`
-	UpdatedAt            time.Time  `json:"updated_at"`
+	ID                  uuid.UUID  `json:"id"`
+	Username            string     `json:"username"`
+	Email               string     `json:"email"`
+	Name                string     `json:"name"`
+	Phone               *string    `json:"phone,omitempty"`
+	PasswordHash        string     `json:"-"` // never serialized
+	IsSuperAdmin        bool       `json:"is_superadmin"`
+	IsActive            bool       `json:"is_active"`
+	ForcePasswordChange bool       `json:"force_password_change"`
+	FailedLoginAttempts int        `json:"failed_login_attempts"`
+	LockedUntil         *time.Time `json:"locked_until,omitempty"`
+	LastLoginAt         *time.Time `json:"last_login_at,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
 }
 
 // LocalUserUpdate holds the mutable fields for an admin user update.
@@ -230,17 +230,17 @@ type LocalGroup struct {
 // SSOProvider holds DB-stored OIDC provider configuration.
 // ClientSecretEnc is never exposed via the API — callers see ClientSecretSet instead.
 type SSOProvider struct {
-	ID               uuid.UUID `json:"id"`
-	Name             string    `json:"name"`
-	ProviderType     string    `json:"provider_type"` // "oidc"
-	IssuerURL        string    `json:"issuer_url"`
-	ClientID         string    `json:"client_id"`
-	ClientSecretEnc  string    `json:"-"` // AES-256-GCM encrypted, base64
-	Scopes           []string  `json:"scopes"`
-	Enabled          bool      `json:"enabled"`
-	AutoProvision    bool      `json:"auto_provision"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID              uuid.UUID `json:"id"`
+	Name            string    `json:"name"`
+	ProviderType    string    `json:"provider_type"` // "oidc"
+	IssuerURL       string    `json:"issuer_url"`
+	ClientID        string    `json:"client_id"`
+	ClientSecretEnc string    `json:"-"` // AES-256-GCM encrypted, base64
+	Scopes          []string  `json:"scopes"`
+	Enabled         bool      `json:"enabled"`
+	AutoProvision   bool      `json:"auto_provision"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // SSOProviderPublic is the API-safe view of an SSOProvider.
@@ -284,38 +284,38 @@ type SSOProviderUpdate struct {
 
 // PasswordPolicy is the singleton row controlling password requirements.
 type PasswordPolicy struct {
-	MinLength               int       `json:"min_length"`
-	RequireUppercase        bool      `json:"require_uppercase"`
-	RequireLowercase        bool      `json:"require_lowercase"`
-	RequireNumber           bool      `json:"require_number"`
-	RequireSpecial          bool      `json:"require_special"`
-	MaxFailedAttempts       int       `json:"max_failed_attempts"`
-	LockoutDurationMinutes  int       `json:"lockout_duration_minutes"`
-	UpdatedAt               time.Time `json:"updated_at"`
+	MinLength              int       `json:"min_length"`
+	RequireUppercase       bool      `json:"require_uppercase"`
+	RequireLowercase       bool      `json:"require_lowercase"`
+	RequireNumber          bool      `json:"require_number"`
+	RequireSpecial         bool      `json:"require_special"`
+	MaxFailedAttempts      int       `json:"max_failed_attempts"`
+	LockoutDurationMinutes int       `json:"lockout_duration_minutes"`
+	UpdatedAt              time.Time `json:"updated_at"`
 }
 
 // PasswordPolicyUpdate holds mutable fields; nil = don't update.
 type PasswordPolicyUpdate struct {
-	MinLength               *int
-	RequireUppercase        *bool
-	RequireLowercase        *bool
-	RequireNumber           *bool
-	RequireSpecial          *bool
-	MaxFailedAttempts       *int
-	LockoutDurationMinutes  *int
+	MinLength              *int
+	RequireUppercase       *bool
+	RequireLowercase       *bool
+	RequireNumber          *bool
+	RequireSpecial         *bool
+	MaxFailedAttempts      *int
+	LockoutDurationMinutes *int
 }
 
 // APIToken is a personal access token for programmatic API access.
 // The raw token is shown once on creation; only the SHA-256 hash is stored.
 // StoredHash is populated by GetAPITokenWithUser for constant-time comparison.
 type APIToken struct {
-	ID          uuid.UUID  `json:"id"`
-	UserID      uuid.UUID  `json:"user_id"`
-	Name        string     `json:"name"`
-	StoredHash  string     `json:"-"` // populated by lookup queries; never serialised
-	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
-	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
+	ID         uuid.UUID  `json:"id"`
+	UserID     uuid.UUID  `json:"user_id"`
+	Name       string     `json:"name"`
+	StoredHash string     `json:"-"` // populated by lookup queries; never serialised
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
 }
 
 // UserNotificationRule defines how a specific user wants to be notified for a

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -51,6 +51,7 @@ type Incident struct {
 	Status         string     `json:"status"`   // open, acknowledged, resolved, snoozed
 	Source         string     `json:"source"`   // grafana, datadog, prometheus, etc.
 	AlertPayload   []byte     `json:"alert_payload"`
+	Fingerprint    *string    `json:"-"`
 	Context        []byte     `json:"context,omitempty"`
 	Analysis       []byte     `json:"analysis,omitempty"`
 	FiredAt        time.Time  `json:"fired_at"`

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -48,10 +48,13 @@ CREATE TABLE IF NOT EXISTS incidents (
 );
 ALTER TABLE incidents ADD COLUMN IF NOT EXISTS escalation_step INT NOT NULL DEFAULT 0;
 
+ALTER TABLE incidents ADD COLUMN IF NOT EXISTS fingerprint CHAR(64);
+
 CREATE INDEX IF NOT EXISTS idx_incidents_team_id     ON incidents(team_id);
 CREATE INDEX IF NOT EXISTS idx_incidents_status      ON incidents(status);
 CREATE INDEX IF NOT EXISTS idx_incidents_fired_at    ON incidents(fired_at DESC);
 CREATE INDEX IF NOT EXISTS idx_incidents_assigned_to ON incidents(assigned_to);
+CREATE INDEX IF NOT EXISTS idx_incidents_fingerprint ON incidents(team_id, fingerprint) WHERE fingerprint IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS schedules (
     id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -55,6 +55,12 @@ CREATE INDEX IF NOT EXISTS idx_incidents_status      ON incidents(status);
 CREATE INDEX IF NOT EXISTS idx_incidents_fired_at    ON incidents(fired_at DESC);
 CREATE INDEX IF NOT EXISTS idx_incidents_assigned_to ON incidents(assigned_to);
 CREATE INDEX IF NOT EXISTS idx_incidents_fingerprint ON incidents(team_id, fingerprint) WHERE fingerprint IS NOT NULL;
+-- Unique partial index: only one active (open/acknowledged/snoozed) incident per fingerprint per team.
+-- Prevents concurrent duplicate inserts that the application-level dedup cannot catch.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_incidents_active_fingerprint_unique
+    ON incidents(team_id, fingerprint)
+    WHERE fingerprint IS NOT NULL
+      AND status IN ('open', 'acknowledged', 'snoozed');
 
 CREATE TABLE IF NOT EXISTS schedules (
     id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Problem

Every webhook POST created a new open incident — no dedup, no resolve path. A Grafana `state: "ok"` callback was silently creating a new `low`/`unknown` severity incident instead of closing the original. Same for wachd-agent `status: "resolved"` and Datadog `alert_type: "success"`.

This means the similarity search, incident graph, and on-call escalation were all built on top of a store that could have hundreds of duplicate incidents for a single real event.

Closes #72.
Unblocks #71.

## What changed

**Schema** (`internal/store/schema.sql`):
- Added `fingerprint CHAR(64)` column with a partial index on `(team_id, fingerprint)` where not null

**Store** (`internal/store/`):
- `Incident` struct: `Fingerprint *string` field
- `CreateIncident`: includes fingerprint in INSERT
- `FindOpenIncidentByFingerprint`: returns most-recent open/acked/snoozed incident for a fingerprint, nil if none
- `ResolveIncidentByFingerprint`: UPDATE to resolved where status IN (open/acknowledged/snoozed); no-op if already resolved

**Webhook handler** (`cmd/server/main.go`):
- `parseWebhookPayload` now returns a 5th `resolved bool` — Grafana `state=ok`, generic `status=resolved`, Datadog `alert_type=success`
- `incidentFingerprint(teamID, source, title)` — SHA-256 of normalized title (lower-cased, trimmed)
- `handleWebhook` flow:
  1. If resolved → `ResolveIncidentByFingerprint` → 202
  2. If open duplicate exists → 202 deduplicated (returns existing incident_id)
  3. Otherwise → create incident as before
  4. Fingerprint lookup errors are logged but do not drop the alert (fail-open)

## Tests

7 new unit tests in `webhook_parser_test.go`:
- `TestParseWebhookPayload_GrafanaResolvedReturnsTrue`
- `TestParseWebhookPayload_AgentResolvedReturnsTrue`
- `TestParseWebhookPayload_DatadogResolvedReturnsTrue`
- `TestIncidentFingerprint_Deterministic`
- `TestIncidentFingerprint_NormalizesTitle`
- `TestIncidentFingerprint_DifferentTeamsDiffer`
- `TestIncidentFingerprint_DifferentSourcesDiffer`

All existing tests updated for the new 5-value return signature.

## Manual verification

Tested end-to-end against a live server + Postgres:

```
POST firing alert     → 200 {"status":"accepted","incident_id":"3bd606c7-..."}
POST same alert again → 202 {"status":"deduplicated","incident_id":"3bd606c7-..."}
POST resolved event   → 202 {"status":"resolved"}
DB: 1 row, status=resolved, fingerprint=a4188e0c...
```

## Checklist

- [x] All database queries scoped by `team_id`
- [x] Parameterized queries only (no string concat)
- [x] Schema migration uses `IF NOT EXISTS` (safe to re-run)
- [x] Fail-open: fingerprint errors never drop an alert
- [x] `go test ./...` all green
- [x] `go build ./...` clean