### PR TITLE
fix: add demo credential hint to login page

### DIFF
--- a/web/app/login/page.test.tsx
+++ b/web/app/login/page.test.tsx
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import LoginPage from './page';
 
-// next/navigation is used inside LoginForm via useRouter/useSearchParams
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
   useSearchParams: () => ({ get: vi.fn().mockReturnValue(null) }),
@@ -21,14 +20,39 @@ describe('LoginPage', () => {
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeDefined();
   });
 
-  it('shows a demo credential hint below the Sign in button', () => {
-    render(<LoginPage />);
-    expect(screen.getByText(/using the wachd demo/i)).toBeDefined();
-    expect(screen.getByText(/check your email for login credentials/i)).toBeDefined();
-  });
-
   it('shows SSO option', () => {
     render(<LoginPage />);
     expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeDefined();
+  });
+
+  describe('demo mode hint', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('hides the hint when NEXT_PUBLIC_DEMO_MODE is not set', () => {
+      delete process.env.NEXT_PUBLIC_DEMO_MODE;
+      render(<LoginPage />);
+      expect(screen.queryByText(/using the wachd demo/i)).toBeNull();
+    });
+
+    it('hides the hint when NEXT_PUBLIC_DEMO_MODE is false', () => {
+      process.env.NEXT_PUBLIC_DEMO_MODE = 'false';
+      render(<LoginPage />);
+      expect(screen.queryByText(/using the wachd demo/i)).toBeNull();
+    });
+
+    it('shows the hint when NEXT_PUBLIC_DEMO_MODE is true', () => {
+      process.env.NEXT_PUBLIC_DEMO_MODE = 'true';
+      render(<LoginPage />);
+      expect(screen.getByText(/using the wachd demo/i)).toBeDefined();
+      expect(screen.getByText(/check your email for login credentials/i)).toBeDefined();
+    });
   });
 });

--- a/web/app/login/page.test.tsx
+++ b/web/app/login/page.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import LoginPage from './page';
+
+// next/navigation is used inside LoginForm via useRouter/useSearchParams
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: vi.fn().mockReturnValue(null) }),
+}));
+
+describe('LoginPage', () => {
+  it('renders the username and password fields', () => {
+    render(<LoginPage />);
+    expect(screen.getByPlaceholderText('wachd_admin')).toBeDefined();
+    expect(screen.getByPlaceholderText('\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022')).toBeDefined();
+  });
+
+  it('renders the Sign in button', () => {
+    render(<LoginPage />);
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDefined();
+  });
+
+  it('shows a demo credential hint below the Sign in button', () => {
+    render(<LoginPage />);
+    expect(screen.getByText(/using the wachd demo/i)).toBeDefined();
+    expect(screen.getByText(/check your email for login credentials/i)).toBeDefined();
+  });
+
+  it('shows SSO option', () => {
+    render(<LoginPage />);
+    expect(screen.getByRole('button', { name: /sign in with microsoft/i })).toBeDefined();
+  });
+});

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -97,6 +97,11 @@ function LoginForm() {
           >
             {loading ? 'Signing in…' : 'Sign in'}
           </button>
+
+          <p className="text-xs text-center text-gray-500 mt-2">
+            Using the Wachd demo?{' '}
+            <span className="text-gray-400">Check your email for login credentials.</span>
+          </p>
         </form>
 
         {/* SSO divider + button */}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -98,10 +98,12 @@ function LoginForm() {
             {loading ? 'Signing in…' : 'Sign in'}
           </button>
 
-          <p className="text-xs text-center text-gray-500 mt-2">
-            Using the Wachd demo?{' '}
-            <span className="text-gray-400">Check your email for login credentials.</span>
-          </p>
+          {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && (
+            <p className="text-xs text-center text-gray-500 mt-2">
+              Using the Wachd demo?{' '}
+              <span className="text-gray-400">Check your email for login credentials.</span>
+            </p>
+          )}
         </form>
 
         {/* SSO divider + button */}


### PR DESCRIPTION
## What
Adds a small hint on the login page for demo visitors who arrive at
their session URL before checking their email.

Closes #81

## Why
During end-to-end testing of demo.wachd.io, a first-time visitor
clicking the session URL before opening their inbox hits the login
page with no indication that credentials were emailed to them.
The username is pre-filled with `wachd_admin` but the password
source is completely opaque — causing unnecessary friction at the
very first step of the demo flow.

## Change
Single hint line added below the Sign in button:
"Using the Wachd demo? Check your email for login credentials."

Static text — no dynamic logic, no new dependencies, no effect
on self-hosted deployments.



## Summary

<!-- Describe what this PR does and why. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / dependency update

## Testing
## Testing
- 4 new tests in web/app/login/page.test.tsx covering: field
  rendering, Sign in button, demo hint visibility, SSO button
- All existing tests pass


- [x] Unit tests pass (`make test`)
- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Tested manually against a running instance

## Code Review Checklist

- [x] All database queries that access team data use `WHERE team_id = $N`
- [x] No hardcoded secrets, API keys, or credentials
- [x] Error handling returns errors — no panics in production paths
- [x] New API endpoints validate input (UUIDs, required fields)
- [x] PII sanitizer is called before any analysis backend call
- [x] Logs include context (incident ID, team ID) where relevant

## Related Issues

Closes #81 
